### PR TITLE
Passwords should be invisible to the accessibility services

### DIFF
--- a/app/src/main/res/layout/entry_edit.xml
+++ b/app/src/main/res/layout/entry_edit.xml
@@ -110,6 +110,7 @@
                         android:layout_width="match_parent"
                         android:layout_height="wrap_content"
                         android:inputType="textPassword"
+                        android:importantForAccessibility="no"
                         android:maxLines="1"
                         android:hint="@string/entry_password" />
                 </android.support.design.widget.TextInputLayout>
@@ -130,6 +131,7 @@
                         android:layout_width="match_parent"
                         android:layout_height="wrap_content"
                         android:inputType="textPassword"
+                        android:importantForAccessibility="no"
                         android:maxLines="1"
                         android:hint="@string/entry_confpassword" />
                 </android.support.design.widget.TextInputLayout>

--- a/app/src/main/res/layout/entry_view_contents.xml
+++ b/app/src/main/res/layout/entry_view_contents.xml
@@ -80,6 +80,7 @@
                 android:layout_height="wrap_content"
                 android:scrollHorizontally="true"
                 android:inputType="textPassword"
+				android:importantForAccessibility="no"
                 android:focusable="false"
                 android:lines="1"
                 style="@style/KeepassDXStyle.TextAppearance.TextEntryItem" />

--- a/app/src/main/res/layout/password.xml
+++ b/app/src/main/res/layout/password.xml
@@ -135,6 +135,7 @@
                             android:layout_height="wrap_content"
                             android:hint="@string/password"
                             android:inputType="textPassword"
+                            android:importantForAccessibility="no"
                             android:imeOptions="actionDone"
                             android:maxLines="1"/>
                     </android.support.design.widget.TextInputLayout>

--- a/app/src/main/res/layout/set_password.xml
+++ b/app/src/main/res/layout/set_password.xml
@@ -60,6 +60,7 @@
                         android:layout_width="match_parent"
                         android:layout_height="wrap_content"
                         android:inputType="textPassword"
+                        android:importantForAccessibility="no"
                         android:maxLines="1"
                         android:hint="@string/hint_pass"/>
                 </android.support.design.widget.TextInputLayout>
@@ -73,6 +74,7 @@
                         android:layout_width="match_parent"
                         android:layout_height="wrap_content"
                         android:inputType="textPassword"
+                        android:importantForAccessibility="no"
                         android:maxLines="1"
                         android:hint="@string/hint_conf_pass"/>
                 </android.support.design.widget.TextInputLayout>


### PR DESCRIPTION
Due to recent attacks, malicious apps that are using the accessibility service can capture all user inputs. In this case, the passwords should be ignored for the accessibility service, so such attacks cannot happen. This is done by our research project in CISPA, Saarland University, Germany.