### PR TITLE
Translation update

### DIFF
--- a/app/src/main/res/values-cs/strings.xml
+++ b/app/src/main/res/values-cs/strings.xml
@@ -446,7 +446,7 @@
     <string name="keyboard_auto_go_action_summary">Automatická akce klíče Jít po stisknutí klíče Pole</string>
     <string name="download_attachment">Stáhnout %1$s</string>
     <string name="download_initialization">Zahajuji…</string>
-    <string name="download_progression">Probíhá: %1$d%</string>
+    <string name="download_progression">Probíhá: %1$d&#37;</string>
     <string name="download_finalization">Dokončuji…</string>
     <string name="download_complete">Ukončeno! Klepnout pro otevření souboru.</string>
     <string name="hide_expired_entries_title">Skrýt propadlé záznamy</string>

--- a/app/src/main/res/values-da/strings.xml
+++ b/app/src/main/res/values-da/strings.xml
@@ -445,7 +445,7 @@
     <string name="keyboard_auto_go_action_summary">Handling af Gå-tasten udføres automatisk, efter der er trykket på en Felt nøgle</string>
     <string name="download_attachment">Hent %1$s</string>
     <string name="download_initialization">Initialiserer…</string>
-    <string name="download_progression">I gang: %1$d%</string>
+    <string name="download_progression">I gang: %1$d&#37;</string>
     <string name="download_finalization">Færdiggørelse…</string>
     <string name="download_complete">Komplet! Tryk for at åbne filen.</string>
     <string name="hide_expired_entries_title">Skjul udløbne poster</string>

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -21,7 +21,9 @@
     Translations from Matthias Dill
     Translations from David Ramiro
 --><resources xmlns:tools="http://schemas.android.com/tools" tools:ignore="MissingTranslation">
-    <string name="feedback">Feedback</string>
+    <string name="contact">Kontakt</string>
+    <string name="contribution">Mitwirken</string>
+    <string name="feedback">Rückmeldung</string>
     <string name="homepage">Webseite</string>
     <string name="about_description">Android-Implementierung des Passwortmanagers KeePass</string>
     <string name="accept">Akzeptieren</string>
@@ -42,12 +44,13 @@
     <string name="clipboard_timeout">Zwischenablage-Timeout</string>
     <string name="clipboard_timeout_summary">Dauer der Speicherung in der Zwischenablage</string>
     <string name="select_to_copy">%1$s in die Zwischenablage kopieren</string>
-    <string name="retrieving_db_key">Datenbank-Schlüsseldatei erzeugen …</string>
+    <string name="retrieving_db_key">Datenbank-Schlüsseldatei erzeugen…</string>
     <string name="database">Datenbank</string>
-    <string name="decrypting_db">Entschlüsselung der Datenbankinhalte …</string>
+    <string name="decrypting_db">Entschlüsselung der Datenbankinhalte…</string>
     <string name="default_checkbox">Als Standard-Datenbank verwenden</string>
     <string name="digits">Zahlen</string>
-    <string name="html_about_licence">KeePassDX © %1$d Kunzisoft. Alle Rechte vorbehalten. Die Nutzung der Software erfolgt auf eigene Verantwortung und ohne jegliche Garantie. Die Applikation ist frei und wird unter den Bedingungen der GNU GPL Version 3 (oder später) verbreitet und lizenziert.</string>
+    <string name="html_about_licence">KeePassDX © %1$d Kunzisoft ist &lt;strong&gt;quelloffen&lt;/strong&gt; und &lt;strong&gt;ohne Werbung&lt;/strong&gt;.\nDie Nutzung der Software erfolgt auf eigene Verantwortung und ohne jegliche Garantie. Die Applikation wird unter den Bedingungen der &lt;strong&gt;GPLv3&lt;/strong&gt; lizenziert.</string>
+    <string name="html_about_contribution">Damit wir &lt;strong&gt;unsere Unabhängigkeit erhalten&lt;/strong&gt;, &lt;strong&gt;Fehler korrigieren&lt;/strong&gt;, &lt;strong&gt;Funktionen hinzufügen&lt;/strong&gt; und &lt;strong&gt;weiterhin aktiv bleiben&lt;/strong&gt; können, zählen wir auf Ihren &lt;strong&gt;Beitrag&lt;/strong&gt;.</string>
     <string name="select_database_file">Vorhandene Datenbank öffnen</string>
     <string name="entry_accessed">Letzter Zugriff</string>
     <string name="entry_cancel">Abbrechen</string>
@@ -97,7 +100,7 @@
     <string name="length">Länge</string>
     <string name="list_size_title">Größe der Listenelemente</string>
     <string name="list_size_summary">Schriftgröße der Listenelemente</string>
-    <string name="loading_database">Datenbank wird geladen …</string>
+    <string name="loading_database">Datenbank wird geladen…</string>
     <string name="lowercase">Kleinbuchstaben</string>
     <string name="hide_password_title">Passwort verstecken</string>
     <string name="hide_password_summary">Passwörter standardmäßig mit (***) maskieren</string>
@@ -121,8 +124,10 @@
     <string name="open_recent">Zuletzt geöffnete Datenbanken</string>
     <string name="omit_backup_search_title">Papierkorb/Sicherungen nicht durchsuchen</string>
     <string name="omit_backup_search_summary">Die Gruppen „Sicherung“ und „Papierkorb“ werden bei der Suche nicht berücksichtigt</string>
-    <string name="progress_create">Neue Datenbank anlegen …</string>
-    <string name="progress_title">Ausführen …</string>
+    <string name="auto_focus_search_title">Schnellsuche</string>
+    <string name="auto_focus_search_summary">Beim Öffnen einer Datenbank eine Suche veranlassen</string>
+    <string name="progress_create">Neue Datenbank anlegen…</string>
+    <string name="progress_title">Ausführen…</string>
     <string name="protection">Sicherheit</string>
     <string name="read_only">Schreibgeschützt</string>
     <string name="read_only_warning">KeePassDX benötigt Schreibrechte, um etwas an der Datenbank zu ändern.</string>
@@ -131,7 +136,7 @@
     <string name="root">Start</string>
     <string name="rounds">Schlüsseltransformationen</string>
     <string name="rounds_explanation">Zusätzliche Schlüsseltransformationen bieten einen besseren Schutz gegen Wörterbuch- oder Brute-Force-Angriffe. Allerdings dauert dann auch das Laden und Speichern der Datenbank entsprechend länger.</string>
-    <string name="saving_database">Datenbank wird gespeichert …</string>
+    <string name="saving_database">Datenbank wird gespeichert…</string>
     <string name="space">Leerzeichen</string>
     <string name="search_label">Suchen</string>
     <string name="sort_db">Natürliche Sortierung</string>
@@ -175,7 +180,6 @@
     <string name="lock_database_screen_off_title">Bildschirmsperre</string>
     <string name="lock_database_screen_off_summary">Datenbank sperren, wenn der Bildschirm ausgeschaltet wird</string>
     <string name="create_keepass_file">Neue Datenbank erstellen</string>
-    <string name="style_choose_title">App-Design</string>
     <string name="assign_master_key">Hauptschlüssel zuweisen</string>
     <string name="path">Pfad</string>
     <string name="file_name">Dateiname</string>
@@ -195,7 +199,6 @@
     <string name="general">Allgemein</string>
     <string name="open_biometric_prompt_store_credential">Biometrische Abfrage öffnen, um Anmeldedaten zu speichern.</string>
     <string name="no_credentials_stored">Diese Datenbank hat noch kein Passwort.</string>
-    <string name="style_choose_summary">App-Design, das in der App genutzt wird</string>
     <string name="encryption">Verschlüsselung</string>
     <string name="key_derivation_function">Schlüsselableitungsfunktion</string>
     <string name="extended_ASCII">Erweiterte ASCII</string>
@@ -297,8 +300,8 @@
     <string name="encryption_chacha20">ChaCha20</string>
     <string name="kdf_AES">AES</string>
     <string name="kdf_Argon2">Argon2</string>
-    <string name="icon_pack_choose_title">Symbolepaket</string>
-    <string name="icon_pack_choose_summary">In der App verwendetes Symbolepaket</string>
+    <string name="icon_pack_choose_title">Symbolpaket</string>
+    <string name="icon_pack_choose_summary">In der App verwendetes Symbolpaket</string>
     <string name="error_move_folder_in_itself">Eine Gruppe kann nicht in sich selbst verschoben werden.</string>
     <string name="menu_copy">Kopieren</string>
     <string name="menu_move">Verschieben</string>
@@ -344,7 +347,15 @@
     <string name="keyboard_key_vibrate_title">Vibrierende Tastendrücke</string>
     <string name="keyboard_key_sound_title">Hörbare Tastendrücke</string>
     <string name="selection_mode">Auswahlmodus</string>
-    <string name="do_not_kill_app">Nicht die App beenden …</string>
+    <string name="remember_database_locations_title">Speicherort der Datenbanken</string>
+    <string name="remember_database_locations_summary">Speicherort der Datenbanken merken</string>
+    <string name="remember_keyfile_locations_title">Speicherort der Schlüsseldateien</string>
+    <string name="remember_keyfile_locations_summary">Speicherort der Schlüssel zu Datenbanken merken</string>
+    <string name="show_recent_files_title">Zuletzt verwendete Dateien anzeigen</string>
+    <string name="show_recent_files_summary">Speicherort zuletzt verwendeter Datenbanken anzeigen</string>
+    <string name="hide_broken_locations_title">Defekte Datenbankverknüpfungen ausblenden</string>
+    <string name="hide_broken_locations_summary">Nicht funktionierende Verknüpfungen in der Liste der zuletzt verwendeten Datenbanken ausblenden</string>
+    <string name="do_not_kill_app">Nicht die App beenden…</string>
     <string name="lock_database_back_root_summary">Datenbank sperren, wenn auf dem Hauptbildschirm der Zurück-Button gedrückt wird</string>
     <string name="clear_clipboard_notification_title">Beim Schließen löschen</string>
     <string name="recycle_bin">Papierkorb</string>
@@ -435,7 +446,7 @@
     <string name="error_save_database">Die Datenbank konnte nicht gespeichert werden.</string>
     <string name="menu_save_database">Datenbank speichern</string>
     <string name="menu_empty_recycle_bin">Papierkorb leeren</string>
-    <string name="command_execution">Befehl ausführen …</string>
+    <string name="command_execution">Befehl ausführen…</string>
     <string name="warning_permanently_delete_nodes">Sind Sie sicher, dass Sie die ausgewählten Knoten dauerhaft löschen möchten\?</string>
     <string name="keystore_not_accessible">Der Schlüsselspeicher ist nicht richtig initialisiert.</string>
     <string name="credential_before_click_biometric_button">Geben Sie das Passwort ein, bevor Sie auf den Biometrie-Button klicken.</string>
@@ -449,9 +460,20 @@
     <string name="keyboard_auto_go_action_summary">Aktion der Go-Taste, die automatisch nach dem Drücken einer Feldtaste ausgeführt wird</string>
     <string name="download_attachment">%1$s herunterladen</string>
     <string name="download_initialization">Initialisieren…</string>
-    <string name="download_progression">Fortschritt: %1$d%</string>
-    <string name="download_finalization">Fertigstellung…</string>
+    <string name="download_progression">Fortschritt: %1$d&#37;</string>
+    <string name="download_finalization">Fertigstellen…</string>
     <string name="download_complete">Vollständig! Tippen Sie, um die Datei zu öffnen.</string>
     <string name="hide_expired_entries_title">Abgelaufene Einträge ausblenden</string>
     <string name="hide_expired_entries_summary">Abgelaufene Einträge werden ausgeblendet</string>
+    <string name="style_choose_title">App-Design</string>
+    <string name="style_choose_summary">App-Design, das in der App genutzt wird</string>
+    <string-array name="list_style_names">
+        <item>Hell</item>
+        <item>Dunkel</item>
+        <item>Schwarz</item>
+        <item>Klassisch Dunkel</item>
+        <item>Himmel und Meer</item>
+        <item>Roter Vulkan</item>
+        <item>Purple Pro</item>
+    </string-array>
 </resources>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -455,7 +455,7 @@
     <string name="keyboard_auto_go_action_summary">Action de la touche Go effectuée automatiquement après avoir appuyé sur une touche de champ</string>
     <string name="download_attachment">Téléchargement %1$s</string>
     <string name="download_initialization">Initialisation…</string>
-    <string name="download_progression">En cours : %1$d%</string>
+    <string name="download_progression">En cours : %1$d&#37;</string>
     <string name="download_finalization">Finalisation…</string>
     <string name="download_complete">Terminé ! Appuyer pour ouvrir le fichier.</string>
     <string name="hide_expired_entries_title">Masquer les entrées expirées</string>

--- a/app/src/main/res/values-nb/strings.xml
+++ b/app/src/main/res/values-nb/strings.xml
@@ -383,7 +383,7 @@
     <string name="error_copy_group_here">Du kan ikke kopiere en gruppe hit.</string>
     <string name="error_otp_secret_key">Hemmelig nøkkel må være i Base32-format.</string>
     <string name="error_otp_digits">"Symbolet må inneholde %1$d  til %2$d siffer."</string>
-    <string name="invalid_db_same_uuid">%1$d med samme UUID %2$s finnes allerede.</string>
+    <string name="invalid_db_same_uuid">%1$s med samme UUID %2$s finnes allerede.</string>
     <string name="creating_database">Oppretter database…</string>
     <string name="menu_security_settings">Sikkerhetsinnstillinger</string>
     <string name="menu_master_key_settings">Hovednøkkelinnstillinger</string>

--- a/app/src/main/res/values-pl/strings.xml
+++ b/app/src/main/res/values-pl/strings.xml
@@ -152,7 +152,7 @@
     <string name="clipboard_error">Niektóre urządzenia nie pozwalają aplikacjom korzystać ze schowka.</string>
     <string name="clipboard_error_clear">Nie można wyczyścić schowka</string>
     <string name="clipboard_swipe_clean">Przesuń, by wyczyścić schowek</string>
-    <string name="html_about_licence">KeePassDX © %1 $d Kunzisoft jest &lt;strong&gt;open source&lt;/strong&gt; i &lt;strong&gt;bez reklam&lt;/strong&gt;.
+    <string name="html_about_licence">KeePassDX © %1$d Kunzisoft jest &lt;strong&gt;open source&lt;/strong&gt; i &lt;strong&gt;bez reklam&lt;/strong&gt;.
 \nJest on dostarczany w stanie, zgodnie z licencją &lt;strong&gt;GPLv3&lt;/strong&gt; bez żadnych gwarancji.</string>
     <string name="entry_not_found">Nie znaleziono danych wejściowych.</string>
     <string name="error_load_database">Nie można załadować bazy danych.</string>
@@ -446,7 +446,7 @@
     <string name="keyboard_auto_go_action_summary">Działanie klawisza Go wykonywane jest automatycznie po naciśnięciu klawisza Field</string>
     <string name="download_attachment">Pobierz %1$s</string>
     <string name="download_initialization">Inicjowanie…</string>
-    <string name="download_progression">W trakcie realizacji: %1$d%</string>
+    <string name="download_progression">W trakcie realizacji: %1$d&#37;</string>
     <string name="download_finalization">Kończę…</string>
     <string name="download_complete">Kompletny! Stuknij, aby otworzyć plik.</string>
     <string name="hide_expired_entries_title">Ukryj wygasłe wpisy</string>

--- a/app/src/main/res/values-ro/strings.xml
+++ b/app/src/main/res/values-ro/strings.xml
@@ -405,7 +405,7 @@
     <string name="contribute">Contribuie</string>
     <string name="download_attachment">Descărcați %1$s</string>
     <string name="download_initialization">Inițializare …</string>
-    <string name="download_progression">In progress: %1$d%</string>
+    <string name="download_progression">In progress: %1$d&#37;</string>
     <string name="download_finalization">Finalizare …</string>
     <string name="download_complete">Complet! Atingeți pentru a deschide fișierul.</string>
     <string name="encryption_rijndael">Rijndael (AES)</string>

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -446,7 +446,7 @@
     <string name="keyboard_auto_go_action_summary">Выполнять команду \"Ввод\" автоматически после нажатия кнопки заполнения поля</string>
     <string name="download_attachment">Скачать %1$s</string>
     <string name="download_initialization">Инициализация…</string>
-    <string name="download_progression">Выполнение: %1$d%</string>
+    <string name="download_progression">Выполнение: %1$d&#37;</string>
     <string name="download_finalization">Завершение…</string>
     <string name="download_complete">Готово! Нажмите, чтобы открыть файл.</string>
     <string name="hide_expired_entries_title">Скрывать устаревшие записи</string>

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -448,7 +448,7 @@
     <string name="keyboard_auto_go_action_summary">填入用户名或密码后直接登录</string>
     <string name="download_attachment">下载%1$s</string>
     <string name="download_initialization">正在初始化…</string>
-    <string name="download_progression">进行中：%1$d%</string>
+    <string name="download_progression">进行中：%1$d&#37;</string>
     <string name="download_finalization">正在完成…</string>
     <string name="download_complete">完成！点击打开文件。</string>
     <string name="hide_expired_entries_title">隐藏过期条目</string>


### PR DESCRIPTION
Several fixes in translation files (`strings.xml`).

- Add and fix German translations
- Fix inconsistencies with translation arguments (e.g. `%1$s`)
- Escape `%` character