### PR TITLE
Early return in readHeaderField

### DIFF
--- a/app/src/main/java/com/kunzisoft/keepass/database/file/DatabaseHeaderKDBX.kt
+++ b/app/src/main/java/com/kunzisoft/keepass/database/file/DatabaseHeaderKDBX.kt
@@ -192,10 +192,11 @@ class DatabaseHeaderKDBX(private val databaseV4: DatabaseKDBX) : DatabaseHeader(
             }
         }
 
+        if (fieldID == PwDbHeaderV4Fields.EndOfHeader)
+            return true
+
         if (fieldData != null)
         when (fieldID) {
-            PwDbHeaderV4Fields.EndOfHeader -> return true
-
             PwDbHeaderV4Fields.CipherID -> setCipher(fieldData)
 
             PwDbHeaderV4Fields.CompressionFlags -> setCompressionFlags(fieldData)


### PR DESCRIPTION
The outer loop in [L167](https://github.com/Kunzisoft/KeePassDX/blob/fea4da2a331a46e91957764ed05276bd066e0254/app/src/main/java/com/kunzisoft/keepass/database/file/DatabaseHeaderKDBX.kt#L167) won't terminate if `EndOfHeader` is a zero sized field.

Should fix this [OOM Exception](https://github.com/Kunzisoft/KeePassDX/projects/23#card-44416432)