### PR TITLE
Use textNoSuggestions type for username input instead.

### DIFF
--- a/app/src/main/res/layout/fragment_entry_edit_contents.xml
+++ b/app/src/main/res/layout/fragment_entry_edit_contents.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!--
  Copyright 2019 Jeremy Jamet / Kunzisoft.
-     
+
  This file is part of KeePassDX.
 
   KeePassDX is free software: you can redistribute it and/or modify
@@ -78,7 +78,7 @@
 					android:id="@+id/entry_edit_user_name"
 					android:layout_width="match_parent"
 					android:layout_height="wrap_content"
-					android:inputType="text"
+					android:inputType="textNoSuggestions"
 					android:importantForAccessibility="no"
 					android:importantForAutofill="no"
 					android:maxLines="1"


### PR DESCRIPTION
Usernames are very specific texts, so general auto correct and/or word suggestion don't make much sense here (and can become annoying if your keyboard isn't smart).

The currently used "text" inputType is supposed to be just plain text, but most keyboards have stopped respecting that and use auto correct / word suggestion on it. This PR replaces it with to "textNoSuggestions".

Extra note: maybe consider KeePassDX's own username autocomplete? like in KeePassXC where usernames or emailed used in other entries would be suggested.

