### PR TITLE
upgrade icon packs to API 30

### DIFF
--- a/icon-pack-classic/build.gradle
+++ b/icon-pack-classic/build.gradle
@@ -1,12 +1,12 @@
 apply plugin: 'com.android.library'
 
 android {
-    compileSdkVersion 29
-    buildToolsVersion '29.0.3'
+    compileSdkVersion 30
+    buildToolsVersion '30.0.2'
 
     defaultConfig {
         minSdkVersion 14
-        targetSdkVersion 29
+        targetSdkVersion 30
     }
 
     resourcePrefix 'classic_'

--- a/icon-pack-material/build.gradle
+++ b/icon-pack-material/build.gradle
@@ -1,12 +1,12 @@
 apply plugin: 'com.android.library'
 
 android {
-    compileSdkVersion 29
-    buildToolsVersion '29.0.3'
+    compileSdkVersion 30
+    buildToolsVersion '30.0.2'
 
     defaultConfig {
         minSdkVersion 14
-        targetSdkVersion 29
+        targetSdkVersion 30
     }
 
     resourcePrefix 'material_'


### PR DESCRIPTION
I noticed that the icon packs where not upgraded to API 30.

While compiling the app for testing purposes i needed to install two different versions of build-tools.
Seems like a minor thing but i thought it might help to keep it in sync.