### PR TITLE
magikeyboard: Don't force full screen EditTexts on large screen devices

### DIFF
--- a/app/src/main/java/com/kunzisoft/keepass/magikeyboard/MagikeyboardService.kt
+++ b/app/src/main/java/com/kunzisoft/keepass/magikeyboard/MagikeyboardService.kt
@@ -178,6 +178,12 @@ class MagikeyboardService : InputMethodService(), KeyboardView.OnKeyboardActionL
         assignKeyboardView()
     }
 
+    override fun onEvaluateFullscreenMode(): Boolean {
+        val fullscreenAllowed = resources.getBoolean(R.bool.magikeyboard_allow_fullscreen_mode)
+
+        return fullscreenAllowed && super.onEvaluateFullscreenMode()
+    }
+
     private fun playVibration(keyCode: Int) {
         when (keyCode) {
             Keyboard.KEYCODE_DELETE -> {}

--- a/app/src/main/res/values-land/config.xml
+++ b/app/src/main/res/values-land/config.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+ Copyright 2021 Jeremy Jamet / Kunzisoft.
+
+ This file is part of KeePassDX.
+
+  KeePassDX is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  KeePassDX is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with KeePassDX.  If not, see <http://www.gnu.org/licenses/>.
+-->
+<resources>
+    <bool name="magikeyboard_allow_fullscreen_mode">true</bool>
+</resources>

--- a/app/src/main/res/values-sw430dp/config.xml
+++ b/app/src/main/res/values-sw430dp/config.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+ Copyright 2021 Jeremy Jamet / Kunzisoft.
+
+ This file is part of KeePassDX.
+
+  KeePassDX is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  KeePassDX is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with KeePassDX.  If not, see <http://www.gnu.org/licenses/>.
+-->
+<resources>
+    <bool name="magikeyboard_allow_fullscreen_mode">false</bool>
+</resources>

--- a/app/src/main/res/values-sw600dp/config.xml
+++ b/app/src/main/res/values-sw600dp/config.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+ Copyright 2021 Jeremy Jamet / Kunzisoft.
+
+ This file is part of KeePassDX.
+
+  KeePassDX is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  KeePassDX is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with KeePassDX.  If not, see <http://www.gnu.org/licenses/>.
+-->
+<resources>
+    <bool name="magikeyboard_allow_fullscreen_mode">false</bool>
+</resources>

--- a/app/src/main/res/values-sw768dp/config.xml
+++ b/app/src/main/res/values-sw768dp/config.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+ Copyright 2021 Jeremy Jamet / Kunzisoft.
+
+ This file is part of KeePassDX.
+
+  KeePassDX is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  KeePassDX is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with KeePassDX.  If not, see <http://www.gnu.org/licenses/>.
+-->
+<resources>
+    <bool name="magikeyboard_allow_fullscreen_mode">false</bool>
+</resources>

--- a/app/src/main/res/values/config.xml
+++ b/app/src/main/res/values/config.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+ Copyright 2021 Jeremy Jamet / Kunzisoft.
+
+ This file is part of KeePassDX.
+
+  KeePassDX is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  KeePassDX is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with KeePassDX.  If not, see <http://www.gnu.org/licenses/>.
+-->
+<resources>
+    <bool name="magikeyboard_allow_fullscreen_mode">false</bool>
+</resources>


### PR DESCRIPTION
Per [1], Android defaults to showing `EditText`s in full screen mode when the device is in landscape orientation. This makes sense for phones, but not so much for larger screen devices, like tablets.

This commit updates MagiKeyboard to not use full screen mode on large screen devices. The condition for disabling full screen mode is the same as in the AOSP keyboard and should match what other OEM keyboards do as well.

[1] https://developer.android.com/reference/android/inputmethodservice/InputMethodService#fullscreen-mode

---

Screenshots (using Magikeyboard in the Discord app as an example):

Tablet:
- Samsung keyboard (no full screen): [Screenshot_20210906-121248_Discord](https://user-images.githubusercontent.com/646253/132247511-e65e8362-32c5-42da-9664-5b293fd4945d.png)
- Magikeyboard (before -- full screen): [Screenshot_20210906-121301_Discord](https://user-images.githubusercontent.com/646253/132247529-a85061a4-b55e-4a3e-8a11-93f60dad7650.png)
- Magikeyboard (after -- no full screen): [Screenshot_20210906-122623_Discord](https://user-images.githubusercontent.com/646253/132247547-732b8ec3-b86c-4b21-8f56-b76a349b6b2b.png)

Phone:
- Samsung keyboard (full screen): [Screenshot_20210906-121056_Discord](https://user-images.githubusercontent.com/646253/132247570-7ce8360b-b93f-4e71-8187-bcb4b48fba93.jpg)
- Magikeyboard (before -- full screen): [Screenshot_20210906-121126_Discord](https://user-images.githubusercontent.com/646253/132247576-fe0e2073-f46a-42f1-b93e-952627eae8b8.jpg)
- Magikeyboard (after -- unchanged behavior): [Screenshot_20210906-122943_Discord](https://user-images.githubusercontent.com/646253/132247589-c0140728-f93d-4fdf-87d4-03ce280e6e2a.jpg)
