### PR TITLE
Add workaround to support Samsung DeX

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -221,6 +221,14 @@
             android:name="com.kunzisoft.keepass.services.KeyboardEntryNotificationService"
             android:enabled="true"
             android:exported="false" />
+        <receiver
+            android:name="com.kunzisoft.keepass.receivers.DexModeReceiver"
+            android:exported="true">
+            <intent-filter>
+                <action android:name="android.app.action.ENTER_KNOX_DESKTOP_MODE" />
+                <action android:name="android.app.action.EXIT_KNOX_DESKTOP_MODE" />
+            </intent-filter>
+        </receiver>
 
         <meta-data android:name="com.sec.android.support.multiwindow" android:value="true" />
     </application>

--- a/app/src/main/java/com/kunzisoft/keepass/activities/FileDatabaseSelectActivity.kt
+++ b/app/src/main/java/com/kunzisoft/keepass/activities/FileDatabaseSelectActivity.kt
@@ -88,6 +88,12 @@ class FileDatabaseSelectActivity : DatabaseModeActivity(),
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
 
+        // Enabling/disabling MagikeyboardService is normally done by DexModeReceiver, but this
+        // additional check will allow the keyboard to be reenabled more easily if the app crashes
+        // or is force quit within DeX mode and then the user leaves DeX mode. Without this, the
+        // user would need to enter and exit DeX mode once to reenable the service.
+        MagikeyboardUtil.setEnabled(this, !DexUtil.isDexMode(resources.configuration))
+
         mFileDatabaseHistoryAction = FileDatabaseHistoryAction.getInstance(applicationContext)
 
         setContentView(R.layout.activity_file_selection)

--- a/app/src/main/java/com/kunzisoft/keepass/receivers/DexModeReceiver.kt
+++ b/app/src/main/java/com/kunzisoft/keepass/receivers/DexModeReceiver.kt
@@ -1,0 +1,33 @@
+package com.kunzisoft.keepass.receivers
+
+import android.content.BroadcastReceiver
+import android.content.ComponentName
+import android.content.Context
+import android.content.Intent
+import android.content.pm.PackageManager
+import android.util.Log
+import com.kunzisoft.keepass.magikeyboard.MagikeyboardService
+import com.kunzisoft.keepass.utils.DexUtil
+import com.kunzisoft.keepass.utils.MagikeyboardUtil
+
+class DexModeReceiver : BroadcastReceiver() {
+    override fun onReceive(context: Context?, intent: Intent?) {
+        val enabled = when (intent?.action) {
+            "android.app.action.ENTER_KNOX_DESKTOP_MODE" -> {
+                Log.i(TAG, "Entered DeX mode")
+                false
+            }
+            "android.app.action.EXIT_KNOX_DESKTOP_MODE" -> {
+                Log.i(TAG, "Left DeX mode")
+                true
+            }
+            else -> return
+        }
+
+        MagikeyboardUtil.setEnabled(context!!, enabled)
+    }
+
+    companion object {
+        private val TAG = DexModeReceiver::class.java.name
+    }
+}

--- a/app/src/main/java/com/kunzisoft/keepass/utils/DexUtil.kt
+++ b/app/src/main/java/com/kunzisoft/keepass/utils/DexUtil.kt
@@ -1,0 +1,27 @@
+package com.kunzisoft.keepass.utils
+
+import android.content.res.Configuration
+import android.util.Log
+
+object DexUtil {
+    private val TAG = DexUtil::class.java.name
+
+    // Determine if the current environment is in DeX mode. Always returns false on non-Samsung
+    // devices.
+    fun isDexMode(config: Configuration): Boolean {
+        // This is the documented way to check this: https://developer.samsung.com/samsung-dex/modify-optimizing.html
+        return try {
+            val configClass = config.javaClass
+            val enabledConstant = configClass.getField("SEM_DESKTOP_MODE_ENABLED").getInt(configClass)
+            val enabledField = configClass.getField("semDesktopModeEnabled").getInt(config)
+            val isEnabled = enabledConstant == enabledField
+
+            Log.d(TAG, "DeX currently enabled: $isEnabled")
+
+            isEnabled
+        } catch (e: Exception) {
+            Log.d(TAG, "Failed to check for DeX mode; likely not Samsung device: $e")
+            false
+        }
+    }
+}

--- a/app/src/main/java/com/kunzisoft/keepass/utils/MagikeyboardUtil.kt
+++ b/app/src/main/java/com/kunzisoft/keepass/utils/MagikeyboardUtil.kt
@@ -1,0 +1,27 @@
+package com.kunzisoft.keepass.utils
+
+import android.content.ComponentName
+import android.content.Context
+import android.content.pm.PackageManager
+import android.util.Log
+import com.kunzisoft.keepass.magikeyboard.MagikeyboardService
+
+object MagikeyboardUtil {
+    private val TAG = MagikeyboardUtil::class.java.name
+
+    // Set whether MagikeyboardService is enabled. This change is persistent and survives app
+    // crashes and device restarts. The state is changed immediately and does not require an app
+    // restart.
+    fun setEnabled(context: Context, enabled: Boolean) {
+        val componentState = if (enabled) {
+            PackageManager.COMPONENT_ENABLED_STATE_ENABLED
+        } else {
+            PackageManager.COMPONENT_ENABLED_STATE_DISABLED
+        }
+
+        Log.d(TAG, "Setting service state: $enabled")
+
+        val component = ComponentName(context, MagikeyboardService::class.java)
+        context.packageManager.setComponentEnabledSetting(component, componentState, PackageManager.DONT_KILL_APP)
+    }
+}


### PR DESCRIPTION
This commit changes the Magikeyboard service behavior so that KeePassDX
is able to run in Samsung DeX mode. Currently, the app cannot run in
DeX mode because apps which have services using `BIND_INPUT_METHOD` are
blocked.

A new broadcast receiver has been added to listen for DeX's enter/leave
events [1] and disable/enable the `Magikeyboard` service appropriately.
The enabled state of a service lives in the Android framework's
`PackageManager` and survives app crashes and device reboots (though it
does get reset when app data is cleared).

Additionally, an extra check is added to `FileDatabaseSelectActivity` to
ensure the service's enabled state is correct. This is necessary if the
app crashes or is force quit within DeX mode and then the user exits DeX
mode. Otherwise, the service would stay disabled until the user entered
and exited DeX again.

With the new behavior, KeePassDX will generally just work with DeX,
though there's one caveat: after the initial installation, the user must
open the app once outside of DeX. Otherwise, Android will not trigger
the broadcast receiver. This could be fixed by making the service
intially disabled in the manifest with `android:enabled="false"`, but
Android's Settings app in SDK 15 through 25 does not correctly refresh
the keyboard list when changing the service from disabled to enabled.
I opted *not* to introduce different behavior based on the API version.

[1] https://developer.samsung.com/sdp/blog/en-us/2017/07/27/samsung-dex-how-to-detect-the-samsung-dex-mode

Fixes: #245