### PR TITLE
fix: remove unused read permission to save database

### DIFF
--- a/app/src/main/java/com/kunzisoft/keepass/database/element/Database.kt
+++ b/app/src/main/java/com/kunzisoft/keepass/database/element/Database.kt
@@ -943,7 +943,7 @@ class Database {
                 } else {
                     var outputStream: OutputStream? = null
                     try {
-                        outputStream = contentResolver.openOutputStream(saveUri, "rwt")
+                        outputStream = contentResolver.openOutputStream(saveUri, "wt")
                         outputStream?.let { definedOutputStream ->
                             val databaseOutput =
                                 mDatabaseKDB?.let { DatabaseOutputKDB(it, definedOutputStream) }


### PR DESCRIPTION
Hi,

First of all, thanks for this amazing project. Finally a decent 100%-FLOSS password manager for Android. Much appreciated work ❤️.

I'm using KPDX along with [RCX](https://github.com/x0b/rcx) which, although I don't like the project much, has implemented a content provider API that KPDX can work with. That allows for file synchronization across a huge variety of storage providers and doesn't require installation of proprietary content providers (such as Google Drive or PCloud proprietary apps).

However, I noticed KPDX was unable to write the DB on RCX remotes, failing with some obscure error message ("Could not save database"). Turns out it was due to KPDX requesting both read and write permissions when saving the database which is unsupported by RCX and AFAIK is unneeded by KPXD. Some remote content providers don't bother supporting r+w permissions because they're tricky to implement and are only ever needed in advanced (niche) use-cases (that I think KPXD could easily work around anyways).

Please note:

- I'm contributing this from my android phone as I don't have access to a laptop/desktop at the moment. It is far from ideal, but I was able to build and install my patch, and I ensured that I was able to load and save a DB. Still, I didn't do extensive testing or comprehensive code-reading. I may very well have missed that the read permission is in fact required somewhere else (although I think it's unlikely). In such case, I'm sorry and I'll contribute support for a write-only strategy when I have access to a proper computer.
- I didn't want to install PCloud proprietary app on my phone, but I highly suspect this also fixes #788
- I found some other "rwt" permissions in KPDX codebase. I couldn't look into them properly, and I'm unsure if they are problematic, but it might be worth having a look at them. File permissions should always be minimal.