### PR TITLE
Unlock DB using NFC tag. Select entry using NFC tag. Use secure NFC tags.

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -35,6 +35,9 @@ android {
             minifyEnabled = false
             proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.pro'
         }
+        debug {
+            applicationIdSuffix 'debug' //todo-op!!! disable
+        }
     }
 
     flavorDimensions "version"

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -20,6 +20,7 @@
     <uses-permission
         android:name="android.permission.QUERY_ALL_PACKAGES"
         tools:ignore="QueryAllPackagesPermission" />
+    <uses-permission android:name="android.permission.NFC" />
 
     <application
         android:label="@string/app_name"

--- a/app/src/main/java/com/kunzisoft/keepass/activities/MainCredentialActivity.kt
+++ b/app/src/main/java/com/kunzisoft/keepass/activities/MainCredentialActivity.kt
@@ -350,8 +350,14 @@ class MainCredentialActivity : DatabaseModeActivity(), AdvancedUnlockFragment.Bu
         }
     }
 
+    override fun onStop() {
+        advancedUnlockFragment?.nfc?.stop() // moved from AdvancedUnlockFragment.connect (onTap NFC tag...)
+        super.onStop()
+    }
+
     override fun onNewIntent(intent: Intent?) {
         super.onNewIntent(intent)
+        if (true == advancedUnlockFragment?.nfc?.checkAndProcessTag(intent)) return
         getUriFromIntent(intent)
     }
 

--- a/app/src/main/java/com/kunzisoft/keepass/services/NfcService.kt
+++ b/app/src/main/java/com/kunzisoft/keepass/services/NfcService.kt
@@ -1,0 +1,221 @@
+package com.kunzisoft.keepass.services
+
+import android.app.Activity
+import android.app.PendingIntent
+import android.content.Context
+import android.content.Intent
+import android.nfc.*
+import android.nfc.tech.*
+import android.util.Log
+import java.io.IOException
+
+class NfcService {
+    companion object {
+        private val TAG = NfcService::class.java.name
+    }
+
+    private var adapter: NfcAdapter? = null
+
+    private fun getAdapter(context: Context?) = adapter
+        ?: context?.getSystemService(Context.NFC_SERVICE)?.let { nfcManager ->
+            (nfcManager as NfcManager).defaultAdapter.also { adapter = it }
+        }
+
+    fun isSupported(context: Context): Boolean = null != getAdapter(context)
+
+    val isEnabled: Boolean get() = true == adapter?.isEnabled
+
+    fun enableDispatch(activity: Activity?, tagActivity: Class<*>?) = try {
+        getAdapter(activity)?.enableForegroundDispatch(activity, PendingIntent.getActivity(activity, 0,
+            Intent(activity, tagActivity).addFlags(Intent.FLAG_ACTIVITY_SINGLE_TOP), PendingIntent.FLAG_MUTABLE),
+            //todo-op!!! check/test. Comment from original code: PendingIntent.FLAG_IMMUTABLE doesn't work, must maybe be mutable
+            null, null)
+    } catch (e: Throwable) { //IllegalStateException
+        Log.e(TAG, "NFC error: Dispatch enable", e)
+    }
+
+    fun disableDispatch(activity: Activity?) = try {
+        adapter?.disableForegroundDispatch(activity)
+    } catch (e: Throwable) { //IllegalStateException
+        Log.e(TAG, "NFC error: Dispatch disable", e)
+    }
+
+    /***/
+
+    var nfcTag: NfcTag? = null
+
+    fun readTag(intent: Intent?, onTag: (NfcTag?, String?, String?) -> Unit): Boolean {
+        val tag: Tag = intent?.getParcelableExtra(NfcAdapter.EXTRA_TAG) ?: return false
+        nfcTag?.close()
+        try {
+            var nfcTagData = intent.getParcelableArrayExtra(NfcAdapter.EXTRA_NDEF_MESSAGES)?.let { messages ->
+                StringBuilder().let { stringBuilder ->
+                    messages.forEach { message ->
+                        (message as NdefMessage).records.forEach {
+                            //if (it.tnf == NdefRecord.TNF_MIME_MEDIA) //todo-op!!! ???
+                            stringBuilder.append(String(it.payload))
+                        }
+                    }
+                }.toString()
+            }
+            if (null == nfcTagData) nfcTagData = ""
+            //nfcTagData = (intent.extras?.get(NfcAdapter.EXTRA_ID)?.toString() ?: "") +
+            //        (intent.extras?.get(NfcAdapter.EXTRA_TAG)?.toString() ?: "") +
+            //        (intent.extras?.get(NfcAdapter.EXTRA_ADAPTER_STATE)?.toString() ?: "") +
+            //        (intent.extras?.get(NfcAdapter.EXTRA_AID)?.toString() ?: "") +
+            //        (intent.extras?.get(NfcAdapter.EXTRA_DATA)?.toString() ?: "") +
+            //        (intent.extras?.get(NfcAdapter.EXTRA_PREFERRED_PAYMENT_CHANGED_REASON)?.toString() ?: "") +
+            //        (intent.extras?.get(NfcAdapter.EXTRA_READER_PRESENCE_CHECK_DELAY)?.toString() ?: "") +
+            //        (intent.extras?.get(NfcAdapter.EXTRA_SECURE_ELEMENT_NAME)?.toString() ?: "") +
+            //        (intent.extras?.get(NfcAdapter.EXTRA_NDEF_MESSAGES)?.toString() ?: "")
+            intent.extras?.keySet()
+                //?.filter { it != NfcAdapter.EXTRA_TAG && it != NfcAdapter.EXTRA_ID }
+                ?.forEach { key ->
+                    intent.extras?.get(key).let { extra ->
+                        (if (extra is ByteArray) NfcTag.bytesToHexString(extra) ?: ""
+                        else extra.toString()
+                                ).let { if (it.isNotBlank()) nfcTagData += "\n$key:$it" }
+                    }
+                }
+            if (nfcTagData.isBlank()) nfcTagData = null
+            nfcTag = NfcTag(tag, nfcTagData)
+            onTag(nfcTag, nfcTagData, null)
+        } catch (e: Throwable) { //FormatException
+            Log.e(TAG, "", e)
+            nfcTag = null
+            onTag(null, null, e.message)
+        }
+        return true
+    }
+}
+
+class NfcTag(val tag: Tag, val data: String?) {
+    companion object {
+        private val TAG = NfcTag::class.java.name
+
+        fun bytesToHexString(src: ByteArray): String? = if (src.isEmpty()) null else
+            StringBuilder().also { for (b in src) it.append(String.format("%02X", b)) }.toString()
+    }
+
+    fun details(): String {
+        return  "$tag\n" +
+                //"tech: ${tag.techList.joinToString()}\n" +
+                "id: $tagId\n" +
+                "tag.describeContents: ${tag.describeContents()}\n" +
+                "dataSize: ${getDataSize()}\n" +
+                "maxSize: $maxSize\n" +
+                "freeSize: ${getFreeSize()}\n" +
+                "isWriteProtected: $isWriteProtected\n" +
+                "canMakeReadOnly: $canMakeReadOnly\n" +
+                "data: $data"
+    }
+
+    val tagId: String?
+        get() {
+            return bytesToHexString(tag.id)
+        }
+
+    fun getDataSize(): Int? = data?.length
+
+    class Tech {
+        var isoDep: IsoDep? = null
+        var mifareClassic: MifareClassic? = null
+        var mifareUltralight: MifareUltralight? = null
+        var ndef: Ndef? = null
+        var ndefFormatable: NdefFormatable? = null
+        var nfcA: NfcA? = null
+        var nfcB: NfcB? = null
+        var nfcBarcode: NfcBarcode? = null
+        var nfcF: NfcF? = null
+        var nfcV: NfcV? = null
+    }
+    private val tech = Tech()
+    init {
+        Log.d(TAG, "NFC tag: ${details()}")
+        if (tag.techList.contains(IsoDep::class.java.canonicalName)) tech.isoDep = IsoDep.get(tag)
+        if (tag.techList.contains(MifareClassic::class.java.canonicalName)) tech.mifareClassic = MifareClassic.get(tag)
+        if (tag.techList.contains(MifareUltralight::class.java.canonicalName)) tech.mifareUltralight = MifareUltralight.get(tag)
+        if (tag.techList.contains(Ndef::class.java.canonicalName)) tech.ndef = Ndef.get(tag)
+        if (tag.techList.contains(NdefFormatable::class.java.canonicalName)) tech.ndefFormatable = NdefFormatable.get(tag)
+        if (tag.techList.contains(NfcA::class.java.canonicalName)) tech.nfcA = NfcA.get(tag)
+        if (tag.techList.contains(NfcB::class.java.canonicalName)) tech.nfcB = NfcB.get(tag)
+        if ( //Build.VERSION.SDK_INT >= Build.VERSION_CODES.JELLY_BEAN_MR1 &&
+            tag.techList.contains(NfcBarcode::class.java.canonicalName)) tech.nfcBarcode = NfcBarcode.get(tag)
+        if (tag.techList.contains(NfcF::class.java.canonicalName)) tech.nfcF = NfcF.get(tag)
+        if (tag.techList.contains(NfcV::class.java.canonicalName)) tech.nfcV = NfcV.get(tag)
+    }
+    //private val tagTech: TagTechnology?
+    //    get() = tech.isoDep
+    //        ?: tech.mifareClassic
+    //        ?: tech.mifareUltralight
+    //        ?: tech.ndef
+    //        ?: tech.ndefFormatable
+    //        ?: tech.nfcA
+    //        ?: tech.nfcB
+    //        ?: tech.nfcBarcode
+    //        ?: tech.nfcF
+    //        ?: tech.nfcV
+
+    private val ndef: Ndef? = tech.ndef
+    val maxSize = ndef?.maxSize
+    val isWriteProtected = true != ndef?.isWritable
+    val canMakeReadOnly = true == ndef?.canMakeReadOnly()
+
+    private val ndefFormatable: NdefFormatable? = tech.ndefFormatable
+    val isNdefSupported = ndef != null || ndefFormatable == null
+
+    private fun getFreeSize(): Int? {
+        val dataSize = getDataSize()
+        return if (dataSize == null || maxSize == null) null else maxSize - dataSize
+    }
+
+    @Throws(IOException::class)
+    fun close() {
+        //tagTech?.close()
+        tech.isoDep?.close()
+        tech.mifareClassic?.close()
+        tech.mifareUltralight?.close()
+        tech.ndef?.close()
+        tech.ndefFormatable?.close()
+        tech.nfcA?.close()
+        tech.nfcB?.close()
+        tech.nfcBarcode?.close()
+        tech.nfcF?.close()
+        tech.nfcV?.close()
+    }
+
+    @Throws(IOException::class, FormatException::class)
+    fun writeData(message: NdefMessage, setWriteProtection: Boolean = false): Boolean {
+        ndef?.let { ndef ->
+            ndef.connect() //tagTech?.connect()
+            if (ndef.isConnected) { //tagTech?.isConnected
+                ndef.writeNdefMessage(message)
+                if (setWriteProtection && ndef.canMakeReadOnly()) ndef.makeReadOnly()
+                ndef.close() //tagTech?.close()
+                return true
+            }
+        } ?: ndefFormatable?.let { ndefFormatable ->
+            ndefFormatable.connect() //tagTech?.connect()
+            if (ndefFormatable.isConnected) { //tagTech?.isConnected
+                ndefFormatable.format(message)
+                ndefFormatable.close() //tagTech?.close()
+                return true
+            }
+        } ?: throw FormatException("Tag does not support ndef")
+        return false
+    }
+
+    //todo-op: write
+    // https://stackoverflow.com/questions/70264201/how-to-write-to-a-mifare-ultralight-card-on-android-studio-java
+    // ...I would ignore most guides out there on the internet as they use the older enableForgroundDispatch API...
+    // ...another example but shows how to use NfcA transceive...
+    // https://stackoverflow.com/a/64921434/2373819
+    // 1 ...To get reliable writing to NFC with Android you should use the newer and much better enableReaderMode API...
+    // https://stackoverflow.com/a/59397667/2373819
+    // 2 ...I would not use the newIntent method as this is very unreliable for writing data, I would use the enableReaderMode if you are targeting a high enough version of Android...
+    // https://www.mifare.net/en/products/tools/taplinx/
+    // 3 ...MIFARE SDK is now TapLinx. This means more supported products, more features, and a redesigned open API...
+    // https://gitlab.com/marc.farssac.busquets/nxp-taplinx-android-nfc-reader-writer
+    // https://github.com/grspy/ulev1plus
+    // https://github.com/mickychanhk/Read-Mifare-Plus-S-Content
+}

--- a/app/src/main/java/com/kunzisoft/keepass/settings/MagikeyboardSettingsFragment.kt
+++ b/app/src/main/java/com/kunzisoft/keepass/settings/MagikeyboardSettingsFragment.kt
@@ -19,11 +19,14 @@
  */
 package com.kunzisoft.keepass.settings
 
+import android.os.Build
 import android.os.Bundle
 import androidx.fragment.app.DialogFragment
 import androidx.preference.Preference
 import androidx.preference.PreferenceFragmentCompat
+import androidx.preference.SwitchPreference
 import com.kunzisoft.keepass.R
+import com.kunzisoft.keepass.activities.dialogs.UnavailableFeatureDialogFragment
 import com.kunzisoft.keepass.settings.preferencedialogfragment.DurationDialogFragmentCompat
 
 class MagikeyboardSettingsFragment : PreferenceFragmentCompat() {
@@ -31,6 +34,17 @@ class MagikeyboardSettingsFragment : PreferenceFragmentCompat() {
     override fun onCreatePreferences(savedInstanceState: Bundle?, rootKey: String?) {
         // Load the preferences from an XML resource
         setPreferencesFromResource(R.xml.preferences_keyboard, rootKey)
+
+        findPreference<SwitchPreference>(getString(R.string.keyboard_selection_nfc_key))?.let { pref ->
+            if (!PreferencesUtil.Nfc.isSupported(requireContext())) pref.isChecked = false
+            pref.setOnPreferenceClickListener {
+                if (!PreferencesUtil.Nfc.isSupported(requireContext())) {
+                    pref.isChecked = false
+                    UnavailableFeatureDialogFragment.getInstance(Build.VERSION_CODES.M).show(parentFragmentManager, "unavailableFeatureDialog")
+                    false
+                } else true
+            }
+        }
     }
 
     override fun onDisplayPreferenceDialog(preference: Preference) {

--- a/app/src/main/java/com/kunzisoft/keepass/settings/NestedAppSettingsFragment.kt
+++ b/app/src/main/java/com/kunzisoft/keepass/settings/NestedAppSettingsFragment.kt
@@ -237,6 +237,29 @@ class NestedAppSettingsFragment : NestedSettingsFragment() {
         setPreferencesFromResource(R.xml.preferences_advanced_unlock, rootKey)
 
         activity?.let { activity ->
+            findPreference<SwitchPreference>(getString(R.string.unlock_nfc_enable_key))?.let { pref ->
+                if (!PreferencesUtil.Nfc.isSupported(requireContext())) pref.isChecked = false
+                pref.setOnPreferenceClickListener {
+                    if (!PreferencesUtil.Nfc.isSupported(requireContext())) {
+                        pref.isChecked = false
+                        UnavailableFeatureDialogFragment.getInstance(Build.VERSION_CODES.M).show(parentFragmentManager, "unavailableFeatureDialog")
+                        false
+                    } else if (pref.isChecked) {
+                        warningMessage(activity, keystoreWarning = true, deleteKeys = false) {
+                            pref.isChecked = true
+                        }
+                        pref.isChecked = false
+                        true
+                    } else {
+                        //todo-op!! Delete only NFC data! Better message for NFC unlock!
+                        warningMessage(activity, keystoreWarning = false, deleteKeys = true) {
+                            pref.isChecked = false
+                        }
+                        pref.isChecked = true
+                        true
+                    }
+                }
+            }
 
             val biometricUnlockEnablePreference: SwitchPreference? = findPreference(getString(R.string.biometric_unlock_enable_key))
             val deviceCredentialUnlockEnablePreference: SwitchPreference? = findPreference(getString(R.string.device_credential_unlock_enable_key))

--- a/app/src/main/java/com/kunzisoft/keepass/view/AdvancedUnlockInfoView.kt
+++ b/app/src/main/java/com/kunzisoft/keepass/view/AdvancedUnlockInfoView.kt
@@ -20,6 +20,7 @@
 package com.kunzisoft.keepass.view
 
 import android.content.Context
+import android.content.res.ColorStateList
 import android.os.Build
 import android.util.AttributeSet
 import android.view.LayoutInflater
@@ -70,6 +71,13 @@ class AdvancedUnlockInfoView @JvmOverloads constructor(context: Context,
             R.drawable.fingerprint -> FingerPrintAnimatedVector(context, unlockIconImageView!!)
             else -> null
         }
+    }
+
+    //todo-op? How to resources.getColor(R.attr.colorAccent)? What after the theme is changed?
+    private var saveDefaultBackgroundTint: Int? = null
+    fun setIconBackgroundTint(color: Int? = null) {
+        if (saveDefaultBackgroundTint == null) saveDefaultBackgroundTint = unlockIconImageView?.backgroundTintList?.defaultColor
+        (color ?: saveDefaultBackgroundTint)?.let { unlockIconImageView?.backgroundTintList = ColorStateList.valueOf(it) }
     }
 
     fun setIconViewClickListener(animation: Boolean = true,

--- a/app/src/main/res/values/donottranslate.xml
+++ b/app/src/main/res/values/donottranslate.xml
@@ -92,6 +92,8 @@
     <string name="remember_keyfile_locations_key" translatable="false">remember_keyfile_locations_key</string>
     <bool name="remember_keyfile_locations_default" translatable="false">true</bool>
     <string name="advanced_unlock_explanation_key" translatable="false">advanced_unlock_explanation_key</string>
+    <string name="unlock_nfc_enable_key" translatable="false">unlock_nfc_enable_key</string>
+    <bool name="unlock_nfc_enable_default" translatable="false">false</bool>
     <string name="biometric_unlock_enable_key" translatable="false">biometric_unlock_enable_key</string>
     <bool name="biometric_unlock_enable_default" translatable="false">false</bool>
     <string name="device_credential_unlock_enable_key" translatable="false">device_credential_unlock_enable_key</string>
@@ -134,6 +136,8 @@
     <string name="keyboard_entry_timeout_default" translatable="false">-1</string>
     <string name="keyboard_selection_entry_key" translatable="false">keyboard_selection_entry_key</string>
     <bool name="keyboard_selection_entry_default" translatable="false">false</bool>
+    <string name="keyboard_selection_nfc_key" translatable="false">keyboard_selection_nfc_key</string>
+    <bool name="keyboard_selection_nfc_default" translatable="false">false</bool>
     <string name="keyboard_save_search_info_key" translatable="false">keyboard_save_search_info_key</string>
     <bool name="keyboard_save_search_info_default" translatable="false">false</bool>
     <string name="keyboard_auto_go_action_key" translatable="false">keyboard_auto_go_action_key</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -406,6 +406,8 @@
     <string name="advanced_unlock">Advanced unlock</string>
     <string name="advanced_unlock_tap_delete">Tap to delete advanced unlocking keys</string>
     <string name="advanced_unlock_explanation_summary">Use advanced unlocking to open a database more easily</string>
+    <string name="unlock_nfc_enable_title">NFC unlocking</string>
+    <string name="unlock_nfc_enable_summary">Lets you tap NFC tag to open the database</string>
     <string name="biometric_unlock_enable_title">Biometric unlocking</string>
     <string name="biometric_unlock_enable_summary">Lets you scan your biometric to open the database</string>
     <string name="device_credential_unlock_enable_title">Device credential unlocking</string>
@@ -481,6 +483,8 @@
     <string name="keyboard_entry_category">Entry</string>
     <string name="keyboard_selection_entry_title">Entry selection</string>
     <string name="keyboard_selection_entry_summary">When viewing an entry in KeePassDX, populate Magikeyboard with that entry</string>
+    <string name="keyboard_selection_nfc_title">NFC tag selection</string>
+    <string name="keyboard_selection_nfc_summary">Tap NFC tag and select entry associated with it</string>
     <string name="keyboard_notification_entry_title">Notification info</string>
     <string name="keyboard_notification_entry_summary">Show a notification when an entry is available</string>
     <string name="keyboard_save_search_info_title">Save shared info</string>
@@ -679,4 +683,8 @@
     <string name="show_entry_colors_summary">Displays foreground and background colors in an entry</string>
     <string name="hide_expired_entries_title">Hide expired entries</string>
     <string name="hide_expired_entries_summary">Expired entries are not shown</string>
+
+    <string name="nfc_not_enabled">Enable NFC to use this feature</string>
+    <string name="nfc_record_overwrite">NFC unlock record exists. Overwrite it?</string>
+    <string name="nfc_unlock_hint">" (Tap NFC tag)"</string>
 </resources>

--- a/app/src/main/res/xml/preferences_advanced_unlock.xml
+++ b/app/src/main/res/xml/preferences_advanced_unlock.xml
@@ -25,6 +25,11 @@
             android:icon="@drawable/prefs_info_24dp"
             android:summary="@string/advanced_unlock_explanation_summary"/>
         <SwitchPreference
+            android:key="@string/unlock_nfc_enable_key"
+            android:title="@string/unlock_nfc_enable_title"
+            android:summary="@string/unlock_nfc_enable_summary"
+            android:defaultValue="@bool/unlock_nfc_enable_default"/>
+        <SwitchPreference
             android:key="@string/biometric_unlock_enable_key"
             android:title="@string/biometric_unlock_enable_title"
             android:summary="@string/biometric_unlock_enable_summary"

--- a/app/src/main/res/xml/preferences_keyboard.xml
+++ b/app/src/main/res/xml/preferences_keyboard.xml
@@ -46,6 +46,11 @@
             android:title="@string/keyboard_selection_entry_title"
             android:summary="@string/keyboard_selection_entry_summary"
             android:defaultValue="@bool/keyboard_selection_entry_default"/>
+        <SwitchPreference
+            android:key="@string/keyboard_selection_nfc_key"
+            android:title="@string/keyboard_selection_nfc_title"
+            android:summary="@string/keyboard_selection_nfc_summary"
+            android:defaultValue="@bool/keyboard_selection_nfc_default"/>
     </PreferenceCategory>
     <PreferenceCategory
         android:title="@string/save">


### PR DESCRIPTION
Plan:
1. Unlock database with NFC tag (incomplete); 
2. Select entry with NFC tag (pending); 

---

Done:
Added NFC permission and NFC switch settings in Advanced Unlock and Autofill/Keyboard;

NFC unlock is integrated in similar way like the other Advanced Unlock options. Looks like it is properly integrated - including the menu item to delete NFC unlock data;

NFC unlock password is stored with different key - not overriding, not disabling the other Advanced Unlock options;

There are few extra lines for easy debug/test in emulator - the emulator do not have NFC; 

Review is needed for the code marked with comment 'todo-op'!

---

Currently it is tested only in read mode - using few NFC transport cards. The DB password is saved together with NFC data; Currently it is using only NFC tag ID; 

Current NFC UI is simple hint - check the pictures; 

At this stage it can be used only for automation - it is not secure, because everyone with card with the same tag ID can unlock the database; 

---

Pending:
1) Write an test with NDef NFC tag;
2) For "NFC select" - start activity from keyboard, because NFC talks only with the foreground activity;
3) Read/Write encrypted NFC tags (Mifare, which are harder to copy/clone);

---

![image](https://user-images.githubusercontent.com/56994434/177388631-9422958e-09d5-4508-8031-49482e2ae44c.png)

![image](https://user-images.githubusercontent.com/56994434/177388646-0cf28c36-17c1-446b-9c52-1154b3bbdb7b.png)

![image](https://user-images.githubusercontent.com/56994434/177388657-9a2266fa-47a7-4e7a-b454-5c993906f08b.png)
