### PR TITLE
Add support for confirm password fields

### DIFF
--- a/app/src/main/java/com/kunzisoft/keepass/autofill/AutofillHelper.kt
+++ b/app/src/main/java/com/kunzisoft/keepass/autofill/AutofillHelper.kt
@@ -123,6 +123,9 @@ object AutofillHelper {
         struct.passwordId?.let { passwordId ->
             builder.setValue(passwordId, AutofillValue.forText(entryInfo.password))
         }
+        struct.confirmPasswordId?.let { confirmPasswordId ->
+            builder.setValue(confirmPasswordId, AutofillValue.forText(entryInfo.password))
+        }
 
         if (entryInfo.expires) {
             val year = entryInfo.expiryTime.getYearInt()

--- a/app/src/main/java/com/kunzisoft/keepass/autofill/KeeAutofillService.kt
+++ b/app/src/main/java/com/kunzisoft/keepass/autofill/KeeAutofillService.kt
@@ -222,6 +222,9 @@ class KeeAutofillService : AutofillService() {
                         }
                         types = types or SaveInfo.SAVE_DATA_TYPE_PASSWORD
                         requiredIds.add(passwordInfo)
+                        parseResult.confirmPasswordId?.let { confirmPasswordId ->
+                            requiredIds.add(confirmPasswordId)
+                        }
                     }
                     // or a credit card form
                     if (requiredIds.isEmpty()) {

--- a/app/src/main/java/com/kunzisoft/keepass/autofill/StructureParser.kt
+++ b/app/src/main/java/com/kunzisoft/keepass/autofill/StructureParser.kt
@@ -120,8 +120,6 @@ class StructureParser(private val structure: AssistStructure) {
             for (i in 0 until node.childCount) {
                 if (parseViewNode(node.getChildAt(i)))
                     returnValue = true
-                if (domainNotEmpty && returnValue)
-                    return true
             }
         }
         return returnValue
@@ -429,6 +427,15 @@ class StructureParser(private val structure: AssistStructure) {
 
         var passwordId: AutofillId? = null
             set(value) {
+                if (field == null) {
+                    field = value
+                } else {
+                    confirmPasswordId = value
+                }
+            }
+
+        var confirmPasswordId: AutofillId? = null
+            set(value) {
                 if (field == null)
                     field = value
             }
@@ -481,6 +488,9 @@ class StructureParser(private val structure: AssistStructure) {
                 all.add(it)
             }
             passwordId?.let {
+                all.add(it)
+            }
+            confirmPasswordId?.let {
                 all.add(it)
             }
             creditCardHolderId?.let {


### PR DESCRIPTION
This pull request adds support for confirm password fields in sign-up pages.

### Current behavior
The current behavior when using a sign up page will fill the username and password, but not any confirm password fields. This is annoying because it forces the user to re-open keepassdx to copy the autogenerated password, and paste it in the form.

### New behavior
The new behavior attempts to detect confirm password fields by checking for additional password fields past the first one. This cuts out the step of re-opening keepassdx and copying the password.

### Testing
I tested this on my own website and the google.com account creation page.
I was not able to find any native apps on my phone that had a confirm password field.