### PR TITLE
remove onRegularBackPressed method

### DIFF
--- a/app/src/main/java/com/kunzisoft/keepass/activities/GroupActivity.kt
+++ b/app/src/main/java/com/kunzisoft/keepass/activities/GroupActivity.kt
@@ -1368,7 +1368,6 @@ class GroupActivity : DatabaseLockActivity(),
                 EntrySelectionHelper.removeInfoFromIntent(intent)
                 if (PreferencesUtil.isLockDatabaseWhenBackButtonOnRootClicked(this)) {
                     lockAndExit()
-                    super.onRegularBackPressed()
                 } else {
                     backToTheAppCaller()
                 }


### PR DESCRIPTION
may fix #1412 

I removed `super.onRegularBackPressed()` method call as `lockAndExit()` creates alert dialog which completes asynchronously but
`super.onRegularBackPressed()` was popping the alert dialog and coming back to same screen. Also `lockAndExit()` handles locking and exiting the app so I think `super.onRegularBackPressed()` is not necessary.