### PR TITLE
Add `JavaVersion` compatible to `icon-pack`

### DIFF
--- a/crypto/build.gradle
+++ b/crypto/build.gradle
@@ -23,7 +23,7 @@ android {
             proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.pro'
         }
     }
-    
+
     externalNativeBuild {
         cmake {
             path "src/main/jni/CMakeLists.txt"
@@ -31,11 +31,12 @@ android {
     }
 
     compileOptions {
-        sourceCompatibility JavaVersion.VERSION_1_8
         targetCompatibility JavaVersion.VERSION_1_8
+        sourceCompatibility JavaVersion.VERSION_1_8
     }
+
     kotlinOptions {
-        jvmTarget = '1.8'
+        jvmTarget = "1.8"
     }
 }
 

--- a/database/build.gradle
+++ b/database/build.gradle
@@ -20,13 +20,16 @@ android {
             proguardFiles getDefaultProguardFile('proguard-android-optimize.txt'), 'proguard-rules.pro'
         }
     }
+
     compileOptions {
-        sourceCompatibility JavaVersion.VERSION_1_8
         targetCompatibility JavaVersion.VERSION_1_8
+        sourceCompatibility JavaVersion.VERSION_1_8
     }
+
     kotlinOptions {
-        jvmTarget = '1.8'
+        jvmTarget = "1.8"
     }
+
     testOptions {
         unitTests {
             includeAndroidResources = true

--- a/icon-pack/build.gradle
+++ b/icon-pack/build.gradle
@@ -10,6 +10,15 @@ android {
         minSdkVersion 14
         targetSdkVersion 33
     }
+
+    compileOptions {
+        targetCompatibility JavaVersion.VERSION_1_8
+        sourceCompatibility JavaVersion.VERSION_1_8
+    }
+
+    kotlinOptions {
+        jvmTarget = "1.8"
+    }
 }
 
 dependencies {


### PR DESCRIPTION
This now also contains Kotlin code.

Note that I had to bump all these values to Java 11 or higher to fully make this work, because one of the Gradle plugins requires at least Java 11 but when providing that on my system it runs into a conflict because of these Gradle properties demanding Java (1.)8 (and I am not experienced enough with Java to understand why it has to be so complicated).
