### PR TITLE
better way to verify GitHub APK files

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,7 +59,23 @@ Optional visual styles are accessible after a contribution (and a congratulatory
 [<img src="https://raw.githubusercontent.com/Kunzisoft/Github-badge/main/get-it-on-github.png"
       alt="Get it on Github"
 	height="80">](https://github.com/Kunzisoft/KeePassDX/releases)
-	
+
+## Verify the authenticity of the downloaded app from GitHub
+1- Download the latest app from [GitHub releases](https://github.com/Kunzisoft/KeePassDX/releases/latest). <br>
+2- Open the directory where you saved the downloaded file in the Terminal on Linux/MacOS. <br>
+3- You must have `keytool` command installed. <br>
+4- Depending on the flavor you downloaded, run:
+```
+keytool -printcert -jarfile KeePassDX-*-libre.apk | grep '7D:55:B8:AF:21:03:81:AA:BF:96:0F:07:E1:7C:F7:85:7B:6D:2A:64:2C:A2:DA:6B:F0:BD:F1:B2:00:36:2F:04'
+```
+Or:
+```
+keytool -printcert -jarfile KeePassDX-*-free.apk | grep '7D:55:B8:AF:21:03:81:AA:BF:96:0F:07:E1:7C:F7:85:7B:6D:2A:64:2C:A2:DA:6B:F0:BD:F1:B2:00:36:2F:04'
+```
+You should get this output:
+```
+SHA256: 7D:55:B8:AF:21:03:81:AA:BF:96:0F:07:E1:7C:F7:85:7B:6D:2A:64:2C:A2:DA:6B:F0:BD:F1:B2:00:36:2F:04
+```
 ## Frequently Asked Questions
 
 Other questions? You can read the [FAQ](https://github.com/Kunzisoft/KeePassDX/wiki/FAQ) 


### PR DESCRIPTION
Verifying the signing certificate hash is way better than verifying the hash of the apk files, because it does not change at all, and it will be very noticeable if it was changed from the README.md file than just GitHub release notes.

And you will not have to calculate the hash and publish it in the future, so less work for you.

Please consider adding it and tell me if there is anything that you need me to add or remove.