### PR TITLE
Bump project dependencies and minSDK to 29 (Android 10)

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -5,13 +5,13 @@ apply plugin: 'kotlin-kapt'
 
 android {
     namespace 'com.kunzisoft.keepass'
-    compileSdkVersion 33
-    buildToolsVersion "33.0.2"
+    compileSdk 34
+    buildToolsVersion "34.0.0"
 
     defaultConfig {
         applicationId "com.kunzisoft.keepass"
-        minSdkVersion 15
-        targetSdkVersion 33
+        minSdk 29
+        targetSdk 33
         versionCode = 129
         versionName = "4.0.6"
         multiDexEnabled true
@@ -94,22 +94,22 @@ android {
     }
 }
 
-def room_version = "2.5.1"
+def room_version = "2.6.1"
 
 dependencies {
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk8:$kotlin_version"
     implementation "com.android.support:multidex:1.0.3"
     implementation "androidx.appcompat:appcompat:$android_appcompat_version"
-    implementation 'androidx.preference:preference-ktx:1.2.0'
+    implementation 'androidx.preference:preference-ktx:1.2.1'
     implementation 'androidx.cardview:cardview:1.0.0'
     implementation 'androidx.constraintlayout:constraintlayout:2.1.4'
-    implementation 'androidx.viewpager2:viewpager2:1.1.0-beta02'
+    implementation 'androidx.viewpager2:viewpager2:1.1.0-rc01'
     implementation 'androidx.documentfile:documentfile:1.0.1'
     implementation 'androidx.biometric:biometric:1.1.0'
-    implementation 'androidx.media:media:1.6.0'
+    implementation 'androidx.media:media:1.7.0'
     // Lifecycle - LiveData - ViewModel - Coroutines
     implementation "androidx.core:core-ktx:$android_core_version"
-    implementation 'androidx.fragment:fragment-ktx:1.6.0'
+    implementation 'androidx.fragment:fragment-ktx:1.7.0'
     implementation "com.google.android.material:material:$android_material_version"
     // Token auto complete
     // From sources until https://github.com/splitwise/TokenAutoComplete/pull/422 fixed
@@ -126,7 +126,7 @@ dependencies {
     // Education
     implementation 'com.getkeepsafe.taptargetview:taptargetview:1.13.3'
     // Apache Commons
-    implementation 'commons-io:commons-io:2.8.0'
+    implementation 'commons-io:commons-io:2.13.0'
     implementation 'commons-codec:commons-codec:1.15'
     // Password generator
     implementation 'me.gosimple:nbvcxz:1.5.0'

--- a/app/src/main/java/com/igreenwood/loupe/Loupe.kt
+++ b/app/src/main/java/com/igreenwood/loupe/Loupe.kt
@@ -201,12 +201,7 @@ class Loupe(imageView: ImageView, container: ViewGroup) : View.OnTouchListener,
         object : GestureDetector.SimpleOnGestureListener() {
             override fun onDown(e: MotionEvent): Boolean = true
 
-            override fun onScroll(
-                e1: MotionEvent,
-                e2: MotionEvent,
-                distanceX: Float,
-                distanceY: Float
-            ): Boolean {
+            override fun onScroll(e1: MotionEvent?, e2: MotionEvent, distanceX: Float, distanceY: Float): Boolean {
                 if (e2.pointerCount != 1) {
                     return true
                 }
@@ -219,12 +214,7 @@ class Loupe(imageView: ImageView, container: ViewGroup) : View.OnTouchListener,
                 return true
             }
 
-            override fun onFling(
-                e1: MotionEvent,
-                e2: MotionEvent,
-                velocityX: Float,
-                velocityY: Float
-            ): Boolean {
+            override fun onFling(e1: MotionEvent?, e2: MotionEvent, velocityX: Float, velocityY: Float): Boolean {
                 if (scale > minScale) {
                     processFlingBitmap(velocityX, velocityY)
                 } else {
@@ -356,76 +346,40 @@ class Loupe(imageView: ImageView, container: ViewGroup) : View.OnTouchListener,
         isViewTranslateAnimationRunning = true
 
 
-        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.KITKAT) {
-            imageView.run {
-                val translationY = if (velY > 0) {
-                    originalViewBounds.top + height - top
-                } else {
-                    originalViewBounds.top - height - top
-                }
-                animate()
-                        .setDuration(dismissAnimationDuration)
-                        .setInterpolator(dismissAnimationInterpolator)
-                        .translationY(translationY.toFloat())
-                        .setUpdateListener {
-                            val amount = calcTranslationAmount()
-                            changeBackgroundAlpha(amount)
-                            onViewTranslateListener?.onViewTranslate(imageView, amount)
-                        }
-                        .setListener(object : Animator.AnimatorListener {
-                            override fun onAnimationStart(p0: Animator) {
-
-                            }
-
-                            override fun onAnimationEnd(p0: Animator) {
-                                isViewTranslateAnimationRunning = false
-                                onViewTranslateListener?.onDismiss(imageView)
-                                cleanup()
-                            }
-
-                            override fun onAnimationCancel(p0: Animator) {
-                                isViewTranslateAnimationRunning = false
-                            }
-
-                            override fun onAnimationRepeat(p0: Animator) {
-                                // no op
-                            }
-                        })
-            }
-        } else {
-            ObjectAnimator.ofFloat(imageView, View.TRANSLATION_Y, if (velY > 0) {
-                originalViewBounds.top + imageView.height - imageView.top
+        imageView.run {
+            val translationY = if (velY > 0) {
+                originalViewBounds.top + height - top
             } else {
-                originalViewBounds.top - imageView.height - imageView.top
-            }.toFloat()).apply {
-                duration = dismissAnimationDuration
-                interpolator = dismissAnimationInterpolator
-                addUpdateListener {
-                    val amount = calcTranslationAmount()
-                    changeBackgroundAlpha(amount)
-                    onViewTranslateListener?.onViewTranslate(imageView, amount)
-                }
-                addListener(object : Animator.AnimatorListener {
-                    override fun onAnimationStart(p0: Animator) {
-                        // no op
-                    }
-
-                    override fun onAnimationEnd(p0: Animator) {
-                        isViewTranslateAnimationRunning = false
-                        onViewTranslateListener?.onDismiss(imageView)
-                        cleanup()
-                    }
-
-                    override fun onAnimationCancel(p0: Animator) {
-                        isViewTranslateAnimationRunning = false
-                    }
-
-                    override fun onAnimationRepeat(p0: Animator) {
-                        // no op
-                    }
-                })
-                start()
+                originalViewBounds.top - height - top
             }
+            animate()
+                    .setDuration(dismissAnimationDuration)
+                    .setInterpolator(dismissAnimationInterpolator)
+                    .translationY(translationY.toFloat())
+                    .setUpdateListener {
+                        val amount = calcTranslationAmount()
+                        changeBackgroundAlpha(amount)
+                        onViewTranslateListener?.onViewTranslate(imageView, amount)
+                    }
+                    .setListener(object : Animator.AnimatorListener {
+                        override fun onAnimationStart(p0: Animator) {
+
+                        }
+
+                        override fun onAnimationEnd(p0: Animator) {
+                            isViewTranslateAnimationRunning = false
+                            onViewTranslateListener?.onDismiss(imageView)
+                            cleanup()
+                        }
+
+                        override fun onAnimationCancel(p0: Animator) {
+                            isViewTranslateAnimationRunning = false
+                        }
+
+                        override fun onAnimationRepeat(p0: Animator) {
+                            // no op
+                        }
+                    })
         }
     }
 
@@ -654,135 +608,73 @@ class Loupe(imageView: ImageView, container: ViewGroup) : View.OnTouchListener,
     private fun restoreViewTransform() {
         val imageView = imageViewRef.get() ?: return
 
-        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.KITKAT) {
-            imageView.run {
-                animate()
-                        .setDuration(restoreAnimationDuration)
-                        .setInterpolator(restoreAnimationInterpolator)
-                        .translationY((originalViewBounds.top - top).toFloat())
-                        .setUpdateListener {
-                            val amount = calcTranslationAmount()
-                            changeBackgroundAlpha(amount)
-                            onViewTranslateListener?.onViewTranslate(this, amount)
+        imageView.run {
+            animate()
+                    .setDuration(restoreAnimationDuration)
+                    .setInterpolator(restoreAnimationInterpolator)
+                    .translationY((originalViewBounds.top - top).toFloat())
+                    .setUpdateListener {
+                        val amount = calcTranslationAmount()
+                        changeBackgroundAlpha(amount)
+                        onViewTranslateListener?.onViewTranslate(this, amount)
+                    }
+                    .setListener(object : Animator.AnimatorListener {
+                        override fun onAnimationStart(p0: Animator) {
+                            // no op
                         }
-                        .setListener(object : Animator.AnimatorListener {
-                            override fun onAnimationStart(p0: Animator) {
-                                // no op
-                            }
 
-                            override fun onAnimationEnd(p0: Animator) {
-                                onViewTranslateListener?.onRestore(imageView)
-                            }
+                        override fun onAnimationEnd(p0: Animator) {
+                            onViewTranslateListener?.onRestore(imageView)
+                        }
 
-                            override fun onAnimationCancel(p0: Animator) {
-                                // no op
-                            }
+                        override fun onAnimationCancel(p0: Animator) {
+                            // no op
+                        }
 
-                            override fun onAnimationRepeat(p0: Animator) {
-                                // no op
-                            }
-                        })
-            }
-        } else {
-            ObjectAnimator.ofFloat(imageView, View.TRANSLATION_Y, (originalViewBounds.top - imageView.top).toFloat()).apply {
-                duration = restoreAnimationDuration
-                interpolator = restoreAnimationInterpolator
-                addUpdateListener {
-                    val amount = calcTranslationAmount()
-                    changeBackgroundAlpha(amount)
-                    onViewTranslateListener?.onViewTranslate(imageView, amount)
-                }
-                addListener(object : Animator.AnimatorListener {
-                    override fun onAnimationStart(p0: Animator) {
-                        // no op
-                    }
-
-                    override fun onAnimationEnd(p0: Animator) {
-                        onViewTranslateListener?.onRestore(imageView)
-                    }
-
-                    override fun onAnimationCancel(p0: Animator) {
-                        // no op
-                    }
-
-                    override fun onAnimationRepeat(p0: Animator) {
-                        // no op
-                    }
-                })
-                start()
-            }
+                        override fun onAnimationRepeat(p0: Animator) {
+                            // no op
+                        }
+                    })
         }
     }
 
     private fun startDragToDismissAnimation() {
         val imageView = imageViewRef.get() ?: return
 
-        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.KITKAT) {
-            imageView.run {
-                val translationY = if (y - initialY > 0) {
-                    originalViewBounds.top + height - top
-                } else {
-                    originalViewBounds.top - height - top
-                }
-                animate()
-                        .setDuration(dismissAnimationDuration)
-                        .setInterpolator(AccelerateDecelerateInterpolator())
-                        .translationY(translationY.toFloat())
-                        .setUpdateListener {
-                            val amount = calcTranslationAmount()
-                            changeBackgroundAlpha(amount)
-                            onViewTranslateListener?.onViewTranslate(this, amount)
+        imageView.run {
+            val translationY = if (y - initialY > 0) {
+                originalViewBounds.top + height - top
+            } else {
+                originalViewBounds.top - height - top
+            }
+            animate()
+                    .setDuration(dismissAnimationDuration)
+                    .setInterpolator(AccelerateDecelerateInterpolator())
+                    .translationY(translationY.toFloat())
+                    .setUpdateListener {
+                        val amount = calcTranslationAmount()
+                        changeBackgroundAlpha(amount)
+                        onViewTranslateListener?.onViewTranslate(this, amount)
+                    }
+                    .setListener(object : Animator.AnimatorListener {
+                        override fun onAnimationStart(p0: Animator) {
+                            isViewTranslateAnimationRunning = true
                         }
-                        .setListener(object : Animator.AnimatorListener {
-                            override fun onAnimationStart(p0: Animator) {
-                                isViewTranslateAnimationRunning = true
-                            }
 
-                            override fun onAnimationEnd(p0: Animator) {
-                                isViewTranslateAnimationRunning = false
-                                onViewTranslateListener?.onDismiss(imageView)
-                                cleanup()
-                            }
+                        override fun onAnimationEnd(p0: Animator) {
+                            isViewTranslateAnimationRunning = false
+                            onViewTranslateListener?.onDismiss(imageView)
+                            cleanup()
+                        }
 
-                            override fun onAnimationCancel(p0: Animator) {
-                                isViewTranslateAnimationRunning = false
-                            }
+                        override fun onAnimationCancel(p0: Animator) {
+                            isViewTranslateAnimationRunning = false
+                        }
 
-                            override fun onAnimationRepeat(p0: Animator) {
-                                // no op
-                            }
-                        })
-            }
-        } else {
-            ObjectAnimator.ofFloat(imageView, View.TRANSLATION_Y, imageView.translationY).apply {
-                duration = dismissAnimationDuration
-                interpolator = AccelerateDecelerateInterpolator()
-                addUpdateListener {
-                    val amount = calcTranslationAmount()
-                    changeBackgroundAlpha(amount)
-                    onViewTranslateListener?.onViewTranslate(imageView, amount)
-                }
-                addListener(object : Animator.AnimatorListener {
-                    override fun onAnimationStart(p0: Animator) {
-                        isViewTranslateAnimationRunning = true
-                    }
-
-                    override fun onAnimationEnd(p0: Animator) {
-                        isViewTranslateAnimationRunning = false
-                        onViewTranslateListener?.onDismiss(imageView)
-                        cleanup()
-                    }
-
-                    override fun onAnimationCancel(p0: Animator) {
-                        isViewTranslateAnimationRunning = false
-                    }
-
-                    override fun onAnimationRepeat(p0: Animator) {
-                        // no op
-                    }
-                })
-                start()
-            }
+                        override fun onAnimationRepeat(p0: Animator) {
+                            // no op
+                        }
+                    })
         }
     }
 

--- a/app/src/main/java/com/kunzisoft/keepass/activities/AutofillLauncherActivity.kt
+++ b/app/src/main/java/com/kunzisoft/keepass/activities/AutofillLauncherActivity.kt
@@ -47,13 +47,10 @@ import com.kunzisoft.keepass.utils.getParcelableExtraCompat
 import com.kunzisoft.keepass.utils.WebDomain
 import java.lang.RuntimeException
 
-@RequiresApi(api = Build.VERSION_CODES.O)
 class AutofillLauncherActivity : DatabaseModeActivity() {
 
     private var mAutofillActivityResultLauncher: ActivityResultLauncher<Intent>? =
-        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O)
             AutofillHelper.buildActivityResultLauncher(this, true)
-        else null
 
     override fun applyCustomStyle(): Boolean {
         return false

--- a/app/src/main/java/com/kunzisoft/keepass/activities/EntryEditActivity.kt
+++ b/app/src/main/java/com/kunzisoft/keepass/activities/EntryEditActivity.kt
@@ -479,11 +479,9 @@ class EntryEditActivity : DatabaseLockActivity(),
 
     private fun entryValidatedForAutofillSelection(database: ContextualDatabase, entry: Entry) {
         // Build Autofill response with the entry selected
-        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
-            AutofillHelper.buildResponseAndSetResult(this@EntryEditActivity,
-                    database,
-                    entry.getEntryInfo(database))
-        }
+        AutofillHelper.buildResponseAndSetResult(this@EntryEditActivity,
+                database,
+                entry.getEntryInfo(database))
         onValidateSpecialMode()
     }
 
@@ -605,14 +603,14 @@ class EntryEditActivity : DatabaseLockActivity(),
         menu?.findItem(R.id.menu_add_attachment)?.apply {
             // Attachment not compatible below KitKat
             isEnabled = !mIsTemplate
-                    && Build.VERSION.SDK_INT >= Build.VERSION_CODES.KITKAT
+                    && true
             isVisible = isEnabled
         }
         menu?.findItem(R.id.menu_add_otp)?.apply {
             // OTP not compatible below KitKat
             isEnabled = mAllowOTP
                     && !mIsTemplate
-                    && Build.VERSION.SDK_INT >= Build.VERSION_CODES.KITKAT
+                    && true
             isVisible = isEnabled
         }
         return super.onPrepareOptionsMenu(menu)

--- a/app/src/main/java/com/kunzisoft/keepass/activities/FileDatabaseSelectActivity.kt
+++ b/app/src/main/java/com/kunzisoft/keepass/activities/FileDatabaseSelectActivity.kt
@@ -101,9 +101,7 @@ class FileDatabaseSelectActivity : DatabaseModeActivity(),
     private var mExternalFileHelper: ExternalFileHelper? = null
 
     private var mAutofillActivityResultLauncher: ActivityResultLauncher<Intent>? =
-        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O)
             AutofillHelper.buildActivityResultLauncher(this)
-        else null
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
@@ -324,9 +322,6 @@ class FileDatabaseSelectActivity : DatabaseModeActivity(),
 
     private fun launchPasswordActivityWithPath(databaseUri: Uri) {
         launchPasswordActivity(databaseUri, null, null)
-        // Delete flickering for kitkat <=
-        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.LOLLIPOP)
-            overridePendingTransition(0, 0)
     }
 
     override fun onResume() {
@@ -500,7 +495,6 @@ class FileDatabaseSelectActivity : DatabaseModeActivity(),
          * -------------------------
          */
 
-        @RequiresApi(api = Build.VERSION_CODES.O)
         fun launchForAutofillResult(activity: AppCompatActivity,
                                     activityResultLauncher: ActivityResultLauncher<Intent>?,
                                     autofillComponent: AutofillComponent,

--- a/app/src/main/java/com/kunzisoft/keepass/activities/fragments/KeyGeneratorFragment.kt
+++ b/app/src/main/java/com/kunzisoft/keepass/activities/fragments/KeyGeneratorFragment.kt
@@ -61,7 +61,7 @@ class KeyGeneratorFragment : DatabaseFragment() {
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
 
-        keyGeneratorPagerAdapter = KeyGeneratorPagerAdapter(this, )
+        keyGeneratorPagerAdapter = KeyGeneratorPagerAdapter(this)
         viewPager = view.findViewById(R.id.tabs_view_pager)
         tabLayout = view.findViewById(R.id.tabs_layout)
         viewPager.adapter = keyGeneratorPagerAdapter

--- a/app/src/main/java/com/kunzisoft/keepass/activities/helpers/EntrySelectionHelper.kt
+++ b/app/src/main/java/com/kunzisoft/keepass/activities/helpers/EntrySelectionHelper.kt
@@ -107,10 +107,8 @@ object EntrySelectionHelper {
     }
 
     fun retrieveSpecialModeFromIntent(intent: Intent): SpecialMode {
-        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
-            if (AutofillHelper.retrieveAutofillComponent(intent) != null)
-                return SpecialMode.SELECTION
-        }
+        if (AutofillHelper.retrieveAutofillComponent(intent) != null)
+            return SpecialMode.SELECTION
         return intent.getEnumExtra<SpecialMode>(KEY_SPECIAL_MODE) ?: SpecialMode.DEFAULT
     }
 
@@ -119,10 +117,8 @@ object EntrySelectionHelper {
     }
 
     fun retrieveTypeModeFromIntent(intent: Intent): TypeMode {
-        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
-            if (AutofillHelper.retrieveAutofillComponent(intent) != null)
-                return TypeMode.AUTOFILL
-        }
+        if (AutofillHelper.retrieveAutofillComponent(intent) != null)
+            return TypeMode.AUTOFILL
         return intent.getEnumExtra<TypeMode>(KEY_TYPE_MODE) ?: TypeMode.DEFAULT
     }
 
@@ -169,11 +165,9 @@ object EntrySelectionHelper {
             SpecialMode.SELECTION -> {
                 val searchInfo: SearchInfo? = retrieveSearchInfoFromIntent(intent)
                 var autofillComponentInit = false
-                if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
-                    AutofillHelper.retrieveAutofillComponent(intent)?.let { autofillComponent ->
-                        autofillSelectionAction.invoke(searchInfo, autofillComponent)
-                        autofillComponentInit = true
-                    }
+                AutofillHelper.retrieveAutofillComponent(intent)?.let { autofillComponent ->
+                    autofillSelectionAction.invoke(searchInfo, autofillComponent)
+                    autofillComponentInit = true
                 }
                 if (!autofillComponentInit) {
                     if (intent.getEnumExtra<SpecialMode>(KEY_SPECIAL_MODE) != null) {

--- a/app/src/main/java/com/kunzisoft/keepass/activities/helpers/ExternalFileHelper.kt
+++ b/app/src/main/java/com/kunzisoft/keepass/activities/helpers/ExternalFileHelper.kt
@@ -151,9 +151,7 @@ class ExternalFileHelper {
             return super.createIntent(context, input).apply {
                 addCategory(Intent.CATEGORY_OPENABLE)
                 addFlags(Intent.FLAG_GRANT_PERSISTABLE_URI_PERMISSION)
-                if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP) {
-                    addFlags(Intent.FLAG_GRANT_PREFIX_URI_PERMISSION)
-                }
+                addFlags(Intent.FLAG_GRANT_PREFIX_URI_PERMISSION)
                 addFlags(Intent.FLAG_GRANT_READ_URI_PERMISSION)
                 addFlags(Intent.FLAG_GRANT_WRITE_URI_PERMISSION)
             }
@@ -166,9 +164,7 @@ class ExternalFileHelper {
             return super.createIntent(context, input).apply {
                 addCategory(Intent.CATEGORY_OPENABLE)
                 addFlags(Intent.FLAG_GRANT_PERSISTABLE_URI_PERMISSION)
-                if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP) {
-                    addFlags(Intent.FLAG_GRANT_PREFIX_URI_PERMISSION)
-                }
+                addFlags(Intent.FLAG_GRANT_PREFIX_URI_PERMISSION)
                 addFlags(Intent.FLAG_GRANT_READ_URI_PERMISSION)
                 addFlags(Intent.FLAG_GRANT_WRITE_URI_PERMISSION)
             }

--- a/app/src/main/java/com/kunzisoft/keepass/autofill/CompatInlineSuggestionsRequest.kt
+++ b/app/src/main/java/com/kunzisoft/keepass/autofill/CompatInlineSuggestionsRequest.kt
@@ -31,7 +31,6 @@ import com.kunzisoft.keepass.utils.readParcelableCompat
 /**
  * Utility class only to prevent java.lang.NoClassDefFoundError for old Android version and new lib compilation
  */
-@RequiresApi(Build.VERSION_CODES.O)
 class CompatInlineSuggestionsRequest : Parcelable {
 
     @TargetApi(Build.VERSION_CODES.R)

--- a/app/src/main/java/com/kunzisoft/keepass/autofill/KeeAutofillService.kt
+++ b/app/src/main/java/com/kunzisoft/keepass/autofill/KeeAutofillService.kt
@@ -47,7 +47,6 @@ import com.kunzisoft.keepass.utils.WebDomain
 import org.joda.time.DateTime
 
 
-@RequiresApi(api = Build.VERSION_CODES.O)
 class KeeAutofillService : AutofillService() {
 
     private var mDatabaseTaskProvider: DatabaseTaskProvider? = null
@@ -274,11 +273,7 @@ class KeeAutofillService : AutofillService() {
                                                 this,
                                                 0,
                                                 Intent(this, AutofillSettingsActivity::class.java),
-                                                if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
-                                                    PendingIntent.FLAG_IMMUTABLE
-                                                } else {
-                                                    0
-                                                }
+                                                PendingIntent.FLAG_IMMUTABLE
                                             )
                                         ).apply {
                                             setContentDescription(getString(R.string.autofill_sign_in_prompt))

--- a/app/src/main/java/com/kunzisoft/keepass/autofill/StructureParser.kt
+++ b/app/src/main/java/com/kunzisoft/keepass/autofill/StructureParser.kt
@@ -34,7 +34,6 @@ import kotlin.collections.ArrayList
 /**
  * Parse AssistStructure and guess username and password fields.
  */
-@RequiresApi(api = Build.VERSION_CODES.O)
 class StructureParser(private val structure: AssistStructure) {
     private var result: Result? = null
     private var usernameIdCandidate: AutofillId? = null
@@ -88,12 +87,10 @@ class StructureParser(private val structure: AssistStructure) {
                 Log.d(TAG, "Autofill domain: $webDomain")
             }
         }
-        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.P) {
-            node.webScheme?.let { webScheme ->
-                if (webScheme.isNotEmpty()) {
-                    result?.webScheme = webScheme
-                    Log.d(TAG, "Autofill scheme: $webScheme")
-                }
+        node.webScheme?.let { webScheme ->
+            if (webScheme.isNotEmpty()) {
+                result?.webScheme = webScheme
+                Log.d(TAG, "Autofill scheme: $webScheme")
             }
         }
         val domainNotEmpty = result?.webDomain?.isNotEmpty() == true
@@ -467,7 +464,6 @@ class StructureParser(private val structure: AssistStructure) {
         return false
     }
 
-    @RequiresApi(api = Build.VERSION_CODES.O)
     class Result {
         var isWebView: Boolean = false
         var applicationId: String? = null

--- a/app/src/main/java/com/kunzisoft/keepass/biometric/AdvancedUnlockFragment.kt
+++ b/app/src/main/java/com/kunzisoft/keepass/biometric/AdvancedUnlockFragment.kt
@@ -98,18 +98,15 @@ class AdvancedUnlockFragment: Fragment(), AdvancedUnlockManager.AdvancedUnlockCa
 
     private val menuProvider: MenuProvider = object: MenuProvider {
         override fun onCreateMenu(menu: Menu, menuInflater: MenuInflater) {
-            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
-                // biometric menu
-                if (mAllowAdvancedUnlockMenu)
-                    menuInflater.inflate(R.menu.advanced_unlock, menu)
-            }
+            // biometric menu
+            if (mAllowAdvancedUnlockMenu)
+                menuInflater.inflate(R.menu.advanced_unlock, menu)
         }
 
         override fun onMenuItemSelected(menuItem: MenuItem): Boolean {
             when (menuItem.itemId) {
-                R.id.menu_keystore_remove_key -> if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
+                R.id.menu_keystore_remove_key ->
                     deleteEncryptedDatabaseKey()
-                }
             }
             return false
         }
@@ -121,9 +118,7 @@ class AdvancedUnlockFragment: Fragment(), AdvancedUnlockManager.AdvancedUnlockCa
         mAdvancedUnlockEnabled = PreferencesUtil.isAdvancedUnlockEnable(context)
         mAutoOpenPromptEnabled = PreferencesUtil.isAdvancedUnlockPromptAutoOpenEnable(context)
         try {
-            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
-                mBuilderListener = context as BuilderListener
-            }
+            mBuilderListener = context as BuilderListener
         } catch (e: ClassCastException) {
             throw ClassCastException(context.toString()
                     + " must implement " + BuilderListener::class.java.name)
@@ -174,31 +169,29 @@ class AdvancedUnlockFragment: Fragment(), AdvancedUnlockManager.AdvancedUnlockCa
     }
 
     private fun onDatabaseLoaded(databaseUri: Uri?) {
-        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
-            // To get device credential unlock result, only if same database uri
-            if (databaseUri != null
-                    && mAdvancedUnlockEnabled) {
-                val deviceCredentialAuthSucceeded = mAdvancedUnlockViewModel.deviceCredentialAuthSucceeded
-                deviceCredentialAuthSucceeded?.let {
-                    if (databaseUri == databaseFileUri) {
-                        if (deviceCredentialAuthSucceeded == true) {
-                            advancedUnlockManager?.advancedUnlockCallback?.onAuthenticationSucceeded()
-                        } else {
-                            advancedUnlockManager?.advancedUnlockCallback?.onAuthenticationFailed()
-                        }
+        // To get device credential unlock result, only if same database uri
+        if (databaseUri != null
+                && mAdvancedUnlockEnabled) {
+            val deviceCredentialAuthSucceeded = mAdvancedUnlockViewModel.deviceCredentialAuthSucceeded
+            deviceCredentialAuthSucceeded?.let {
+                if (databaseUri == databaseFileUri) {
+                    if (deviceCredentialAuthSucceeded == true) {
+                        advancedUnlockManager?.advancedUnlockCallback?.onAuthenticationSucceeded()
                     } else {
-                        disconnect()
+                        advancedUnlockManager?.advancedUnlockCallback?.onAuthenticationFailed()
                     }
-                } ?: run {
-                    if (databaseUri != databaseFileUri) {
-                        connect(databaseUri)
-                    }
+                } else {
+                    disconnect()
                 }
-            } else {
-                disconnect()
+            } ?: run {
+                if (databaseUri != databaseFileUri) {
+                    connect(databaseUri)
+                }
             }
-            mAdvancedUnlockViewModel.deviceCredentialAuthSucceeded = null
+        } else {
+            disconnect()
         }
+        mAdvancedUnlockViewModel.deviceCredentialAuthSucceeded = null
     }
 
     /**
@@ -206,38 +199,35 @@ class AdvancedUnlockFragment: Fragment(), AdvancedUnlockManager.AdvancedUnlockCa
      */
     private fun checkUnlockAvailability() {
         context?.let { context ->
-            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
-                allowOpenBiometricPrompt = true
-                if (PreferencesUtil.isBiometricUnlockEnable(context)) {
-                    // biometric not supported (by API level or hardware) so keep option hidden
-                    // or manually disable
-                    val biometricCanAuthenticate = AdvancedUnlockManager.canAuthenticate(context)
-                    if (!PreferencesUtil.isAdvancedUnlockEnable(context)
-                            || biometricCanAuthenticate == BiometricManager.BIOMETRIC_ERROR_HW_UNAVAILABLE
-                            || biometricCanAuthenticate == BiometricManager.BIOMETRIC_ERROR_NO_HARDWARE) {
-                        toggleMode(Mode.BIOMETRIC_UNAVAILABLE)
-                    } else if (biometricCanAuthenticate == BiometricManager.BIOMETRIC_ERROR_SECURITY_UPDATE_REQUIRED) {
-                        toggleMode(Mode.BIOMETRIC_SECURITY_UPDATE_REQUIRED)
-                    } else {
-                        // biometric is available but not configured, show icon but in disabled state with some information
-                        if (biometricCanAuthenticate == BiometricManager.BIOMETRIC_ERROR_NONE_ENROLLED) {
-                            toggleMode(Mode.DEVICE_CREDENTIAL_OR_BIOMETRIC_NOT_CONFIGURED)
-                        } else {
-                            selectMode()
-                        }
-                    }
-                } else if (PreferencesUtil.isDeviceCredentialUnlockEnable(context)) {
-                    if (AdvancedUnlockManager.isDeviceSecure(context)) {
-                        selectMode()
-                    } else {
+            allowOpenBiometricPrompt = true
+            if (PreferencesUtil.isBiometricUnlockEnable(context)) {
+                // biometric not supported (by API level or hardware) so keep option hidden
+                // or manually disable
+                val biometricCanAuthenticate = AdvancedUnlockManager.canAuthenticate(context)
+                if (!PreferencesUtil.isAdvancedUnlockEnable(context)
+                        || biometricCanAuthenticate == BiometricManager.BIOMETRIC_ERROR_HW_UNAVAILABLE
+                        || biometricCanAuthenticate == BiometricManager.BIOMETRIC_ERROR_NO_HARDWARE) {
+                    toggleMode(Mode.BIOMETRIC_UNAVAILABLE)
+                } else if (biometricCanAuthenticate == BiometricManager.BIOMETRIC_ERROR_SECURITY_UPDATE_REQUIRED) {
+                    toggleMode(Mode.BIOMETRIC_SECURITY_UPDATE_REQUIRED)
+                } else {
+                    // biometric is available but not configured, show icon but in disabled state with some information
+                    if (biometricCanAuthenticate == BiometricManager.BIOMETRIC_ERROR_NONE_ENROLLED) {
                         toggleMode(Mode.DEVICE_CREDENTIAL_OR_BIOMETRIC_NOT_CONFIGURED)
+                    } else {
+                        selectMode()
                     }
+                }
+            } else if (PreferencesUtil.isDeviceCredentialUnlockEnable(context)) {
+                if (AdvancedUnlockManager.isDeviceSecure(context)) {
+                    selectMode()
+                } else {
+                    toggleMode(Mode.DEVICE_CREDENTIAL_OR_BIOMETRIC_NOT_CONFIGURED)
                 }
             }
         }
     }
 
-    @RequiresApi(Build.VERSION_CODES.M)
     private fun selectMode() {
         // Check if fingerprint well init (be called the first time the fingerprint is configured
         // and the activity still active)
@@ -270,7 +260,6 @@ class AdvancedUnlockFragment: Fragment(), AdvancedUnlockManager.AdvancedUnlockCa
         }
     }
 
-    @RequiresApi(Build.VERSION_CODES.M)
     private fun toggleMode(newBiometricMode: Mode) {
         if (newBiometricMode != biometricMode) {
             biometricMode = newBiometricMode
@@ -278,14 +267,12 @@ class AdvancedUnlockFragment: Fragment(), AdvancedUnlockManager.AdvancedUnlockCa
         }
     }
 
-    @RequiresApi(Build.VERSION_CODES.M)
     private fun initNotAvailable() {
         showViews(false)
 
         mAdvancedUnlockInfoView?.setIconViewClickListener(null)
     }
 
-    @RequiresApi(Build.VERSION_CODES.M)
     private fun openBiometricSetting() {
         mAdvancedUnlockInfoView?.setIconViewClickListener {
             try {
@@ -293,7 +280,7 @@ class AdvancedUnlockFragment: Fragment(), AdvancedUnlockManager.AdvancedUnlockCa
                     Build.VERSION.SDK_INT >= Build.VERSION_CODES.R -> {
                         context?.startActivity(Intent(Settings.ACTION_BIOMETRIC_ENROLL))
                     }
-                    Build.VERSION.SDK_INT >= Build.VERSION_CODES.P -> {
+                    true -> {
                         @Suppress("DEPRECATION") context
                             ?.startActivity(Intent(Settings.ACTION_FINGERPRINT_ENROLL))
                     }
@@ -308,7 +295,6 @@ class AdvancedUnlockFragment: Fragment(), AdvancedUnlockManager.AdvancedUnlockCa
         }
     }
 
-    @RequiresApi(Build.VERSION_CODES.M)
     private fun initSecurityUpdateRequired() {
         showViews(true)
         setAdvancedUnlockedTitleView(R.string.biometric_security_update_required)
@@ -316,7 +302,6 @@ class AdvancedUnlockFragment: Fragment(), AdvancedUnlockManager.AdvancedUnlockCa
         openBiometricSetting()
     }
 
-    @RequiresApi(Build.VERSION_CODES.M)
     private fun initNotConfigured() {
         showViews(true)
         setAdvancedUnlockedTitleView(R.string.configure_biometric)
@@ -325,7 +310,6 @@ class AdvancedUnlockFragment: Fragment(), AdvancedUnlockManager.AdvancedUnlockCa
         openBiometricSetting()
     }
 
-    @RequiresApi(Build.VERSION_CODES.M)
     private fun initKeyManagerNotAvailable() {
         showViews(true)
         setAdvancedUnlockedTitleView(R.string.keystore_not_accessible)
@@ -333,7 +317,6 @@ class AdvancedUnlockFragment: Fragment(), AdvancedUnlockManager.AdvancedUnlockCa
         openBiometricSetting()
     }
 
-    @RequiresApi(Build.VERSION_CODES.M)
     private fun initWaitData() {
         showViews(true)
         setAdvancedUnlockedTitleView(R.string.unavailable)
@@ -347,7 +330,6 @@ class AdvancedUnlockFragment: Fragment(), AdvancedUnlockManager.AdvancedUnlockCa
         }
     }
 
-    @RequiresApi(Build.VERSION_CODES.M)
     private fun openAdvancedUnlockPrompt(cryptoPrompt: AdvancedUnlockCryptoPrompt) {
         lifecycleScope.launch(Dispatchers.Main) {
             if (allowOpenBiometricPrompt) {
@@ -364,7 +346,6 @@ class AdvancedUnlockFragment: Fragment(), AdvancedUnlockManager.AdvancedUnlockCa
         }
     }
 
-    @RequiresApi(Build.VERSION_CODES.M)
     private fun initEncryptData() {
         showViews(true)
         setAdvancedUnlockedTitleView(R.string.unlock_and_link_biometric)
@@ -378,7 +359,6 @@ class AdvancedUnlockFragment: Fragment(), AdvancedUnlockManager.AdvancedUnlockCa
         } ?: throw Exception("AdvancedUnlockManager not initialized")
     }
 
-    @RequiresApi(Build.VERSION_CODES.M)
     private fun initDecryptData() {
         showViews(true)
         setAdvancedUnlockedTitleView(R.string.unlock)
@@ -409,23 +389,21 @@ class AdvancedUnlockFragment: Fragment(), AdvancedUnlockManager.AdvancedUnlockCa
     }
 
     private fun initAdvancedUnlockMode() {
-        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
-            mAllowAdvancedUnlockMenu = false
-            try {
-                when (biometricMode) {
-                    Mode.BIOMETRIC_UNAVAILABLE -> initNotAvailable()
-                    Mode.BIOMETRIC_SECURITY_UPDATE_REQUIRED -> initSecurityUpdateRequired()
-                    Mode.DEVICE_CREDENTIAL_OR_BIOMETRIC_NOT_CONFIGURED -> initNotConfigured()
-                    Mode.KEY_MANAGER_UNAVAILABLE -> initKeyManagerNotAvailable()
-                    Mode.WAIT_CREDENTIAL -> initWaitData()
-                    Mode.STORE_CREDENTIAL -> initEncryptData()
-                    Mode.EXTRACT_CREDENTIAL -> initDecryptData()
-                }
-            } catch (e: Exception) {
-                onGenericException(e)
+        mAllowAdvancedUnlockMenu = false
+        try {
+            when (biometricMode) {
+                Mode.BIOMETRIC_UNAVAILABLE -> initNotAvailable()
+                Mode.BIOMETRIC_SECURITY_UPDATE_REQUIRED -> initSecurityUpdateRequired()
+                Mode.DEVICE_CREDENTIAL_OR_BIOMETRIC_NOT_CONFIGURED -> initNotConfigured()
+                Mode.KEY_MANAGER_UNAVAILABLE -> initKeyManagerNotAvailable()
+                Mode.WAIT_CREDENTIAL -> initWaitData()
+                Mode.STORE_CREDENTIAL -> initEncryptData()
+                Mode.EXTRACT_CREDENTIAL -> initDecryptData()
             }
-            invalidateBiometricMenu()
+        } catch (e: Exception) {
+            onGenericException(e)
         }
+        invalidateBiometricMenu()
     }
 
     private fun invalidateBiometricMenu() {
@@ -444,7 +422,6 @@ class AdvancedUnlockFragment: Fragment(), AdvancedUnlockManager.AdvancedUnlockCa
         }
     }
 
-    @RequiresApi(Build.VERSION_CODES.M)
     fun connect(databaseUri: Uri) {
         showViews(true)
         this.databaseFileUri = databaseUri
@@ -463,7 +440,6 @@ class AdvancedUnlockFragment: Fragment(), AdvancedUnlockManager.AdvancedUnlockCa
         checkUnlockAvailability()
     }
 
-    @RequiresApi(Build.VERSION_CODES.M)
     fun disconnect(hideViews: Boolean = true,
                    closePrompt: Boolean = true) {
         this.databaseFileUri = null
@@ -480,7 +456,6 @@ class AdvancedUnlockFragment: Fragment(), AdvancedUnlockManager.AdvancedUnlockCa
         }
     }
 
-    @RequiresApi(Build.VERSION_CODES.M)
     fun deleteEncryptedDatabaseKey() {
         mAllowAdvancedUnlockMenu = false
         advancedUnlockManager?.closeBiometricPrompt()
@@ -491,7 +466,6 @@ class AdvancedUnlockFragment: Fragment(), AdvancedUnlockManager.AdvancedUnlockCa
         } ?: checkUnlockAvailability()
     }
 
-    @RequiresApi(Build.VERSION_CODES.M)
     override fun onAuthenticationError(errorCode: Int, errString: CharSequence) {
         lifecycleScope.launch(Dispatchers.Main) {
             Log.e(TAG, "Biometric authentication error. Code : $errorCode Error : $errString")
@@ -499,7 +473,6 @@ class AdvancedUnlockFragment: Fragment(), AdvancedUnlockManager.AdvancedUnlockCa
         }
     }
 
-    @RequiresApi(Build.VERSION_CODES.M)
     override fun onAuthenticationFailed() {
         lifecycleScope.launch(Dispatchers.Main) {
             Log.e(TAG, "Biometric authentication failed, biometric not recognized")
@@ -507,7 +480,6 @@ class AdvancedUnlockFragment: Fragment(), AdvancedUnlockManager.AdvancedUnlockCa
         }
     }
 
-    @RequiresApi(Build.VERSION_CODES.M)
     override fun onAuthenticationSucceeded() {
         lifecycleScope.launch(Dispatchers.Main) {
             when (biometricMode) {
@@ -569,17 +541,14 @@ class AdvancedUnlockFragment: Fragment(), AdvancedUnlockManager.AdvancedUnlockCa
         }
     }
 
-    @RequiresApi(Build.VERSION_CODES.M)
     override fun onUnrecoverableKeyException(e: Exception) {
         setAdvancedUnlockedMessageView(R.string.advanced_unlock_invalid_key)
     }
 
-    @RequiresApi(Build.VERSION_CODES.M)
     override fun onInvalidKeyException(e: Exception) {
         setAdvancedUnlockedMessageView(R.string.advanced_unlock_invalid_key)
     }
 
-    @RequiresApi(Build.VERSION_CODES.M)
     override fun onGenericException(e: Exception) {
         val errorMessage = e.cause?.localizedMessage ?: e.localizedMessage ?: ""
         setAdvancedUnlockedMessageView(errorMessage)
@@ -598,21 +567,18 @@ class AdvancedUnlockFragment: Fragment(), AdvancedUnlockManager.AdvancedUnlockCa
         }
     }
 
-    @RequiresApi(Build.VERSION_CODES.M)
     private fun setAdvancedUnlockedTitleView(textId: Int) {
         lifecycleScope.launch(Dispatchers.Main) {
             mAdvancedUnlockInfoView?.setTitle(textId)
         }
     }
 
-    @RequiresApi(Build.VERSION_CODES.M)
     private fun setAdvancedUnlockedMessageView(textId: Int) {
         lifecycleScope.launch(Dispatchers.Main) {
             mAdvancedUnlockInfoView?.setMessage(textId)
         }
     }
 
-    @RequiresApi(Build.VERSION_CODES.M)
     private fun setAdvancedUnlockedMessageView(text: CharSequence) {
         lifecycleScope.launch(Dispatchers.Main) {
             mAdvancedUnlockInfoView?.setMessage(text)
@@ -637,12 +603,10 @@ class AdvancedUnlockFragment: Fragment(), AdvancedUnlockManager.AdvancedUnlockCa
     }
 
     override fun onPause() {
-        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
-            if (!keepConnection) {
-                // If close prompt, bug "user not authenticated in Android R"
-                disconnect(false)
-                advancedUnlockManager = null
-            }
+        if (!keepConnection) {
+            // If close prompt, bug "user not authenticated in Android R"
+            disconnect(false)
+            advancedUnlockManager = null
         }
 
         super.onPause()
@@ -655,11 +619,9 @@ class AdvancedUnlockFragment: Fragment(), AdvancedUnlockManager.AdvancedUnlockCa
     }
 
     override fun onDestroy() {
-        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
-            disconnect()
-            advancedUnlockManager = null
-            mBuilderListener = null
-        }
+        disconnect()
+        advancedUnlockManager = null
+        mBuilderListener = null
 
         super.onDestroy()
     }

--- a/app/src/main/java/com/kunzisoft/keepass/biometric/AdvancedUnlockManager.kt
+++ b/app/src/main/java/com/kunzisoft/keepass/biometric/AdvancedUnlockManager.kt
@@ -48,7 +48,6 @@ import javax.crypto.KeyGenerator
 import javax.crypto.SecretKey
 import javax.crypto.spec.IvParameterSpec
 
-@RequiresApi(api = Build.VERSION_CODES.M)
 class AdvancedUnlockManager(private var retrieveContext: () -> FragmentActivity) {
 
     private var keyStore: KeyStore? = null
@@ -150,9 +149,8 @@ class AdvancedUnlockManager(private var retrieveContext: () -> FragmentActivity)
                                             setUserAuthenticationRequired(true)
                                         }
                                         // To store in the security chip
-                                        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.P
-                                            && retrieveContext().packageManager.hasSystemFeature(
-                                                PackageManager.FEATURE_STRONGBOX_KEYSTORE)) {
+                                        if (retrieveContext().packageManager.hasSystemFeature(
+                                            PackageManager.FEATURE_STRONGBOX_KEYSTORE)) {
                                             setIsStrongBoxBacked(true)
                                         }
                                     }
@@ -173,7 +171,7 @@ class AdvancedUnlockManager(private var retrieveContext: () -> FragmentActivity)
         return null
     }
 
-    @Synchronized fun initEncryptData(actionIfCypherInit: (cryptoPrompt: AdvancedUnlockCryptoPrompt) -> Unit,) {
+    @Synchronized fun initEncryptData(actionIfCypherInit: (cryptoPrompt: AdvancedUnlockCryptoPrompt) -> Unit) {
         initEncryptData(actionIfCypherInit, true)
     }
 
@@ -374,7 +372,6 @@ class AdvancedUnlockManager(private var retrieveContext: () -> FragmentActivity)
         private const val ADVANCED_UNLOCK_BLOCKS_MODES = KeyProperties.BLOCK_MODE_CBC
         private const val ADVANCED_UNLOCK_ENCRYPTION_PADDING = KeyProperties.ENCRYPTION_PADDING_PKCS7
 
-        @RequiresApi(api = Build.VERSION_CODES.M)
         fun canAuthenticate(context: Context): Int {
             return try {
                 BiometricManager.from(context).canAuthenticate(
@@ -476,29 +473,27 @@ class AdvancedUnlockManager(private var retrieveContext: () -> FragmentActivity)
         }
 
         fun deleteAllEntryKeysInKeystoreForBiometric(activity: FragmentActivity) {
-            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
-                deleteEntryKeyInKeystoreForBiometric(
-                    activity,
-                    object : AdvancedUnlockErrorCallback {
-                        fun showException(e: Exception) {
-                            Toast.makeText(activity,
-                                activity.getString(R.string.advanced_unlock_scanning_error, e.localizedMessage),
-                                Toast.LENGTH_SHORT).show()
-                        }
+            deleteEntryKeyInKeystoreForBiometric(
+                activity,
+                object : AdvancedUnlockErrorCallback {
+                    fun showException(e: Exception) {
+                        Toast.makeText(activity,
+                            activity.getString(R.string.advanced_unlock_scanning_error, e.localizedMessage),
+                            Toast.LENGTH_SHORT).show()
+                    }
 
-                        override fun onUnrecoverableKeyException(e: Exception) {
-                            showException(e)
-                        }
+                    override fun onUnrecoverableKeyException(e: Exception) {
+                        showException(e)
+                    }
 
-                        override fun onInvalidKeyException(e: Exception) {
-                            showException(e)
-                        }
+                    override fun onInvalidKeyException(e: Exception) {
+                        showException(e)
+                    }
 
-                        override fun onGenericException(e: Exception) {
-                            showException(e)
-                        }
-                    })
-            }
+                    override fun onGenericException(e: Exception) {
+                        showException(e)
+                    }
+                })
             CipherDatabaseAction.getInstance(activity.applicationContext).deleteAll()
         }
     }

--- a/app/src/main/java/com/kunzisoft/keepass/services/AdvancedUnlockNotificationService.kt
+++ b/app/src/main/java/com/kunzisoft/keepass/services/AdvancedUnlockNotificationService.kt
@@ -64,11 +64,7 @@ class AdvancedUnlockNotificationService : NotificationService() {
         val pendingDeleteIntent = PendingIntent.getBroadcast(this,
             4577,
             Intent(REMOVE_ADVANCED_UNLOCK_KEY_ACTION),
-            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
-                PendingIntent.FLAG_IMMUTABLE
-            } else {
-                0
-            })
+            PendingIntent.FLAG_IMMUTABLE)
         val biometricUnlockEnabled = PreferencesUtil.isBiometricUnlockEnable(this)
         val notificationBuilder = buildNewNotification().apply {
             setSmallIcon(if (biometricUnlockEnabled) {

--- a/app/src/main/java/com/kunzisoft/keepass/services/AttachmentFileNotificationService.kt
+++ b/app/src/main/java/com/kunzisoft/keepass/services/AttachmentFileNotificationService.kt
@@ -200,11 +200,8 @@ class AttachmentFileNotificationService: LockNotificationService() {
                 setDataAndType(attachmentNotification.uri,
                         contentResolver.getType(attachmentNotification.uri))
                 addFlags(Intent.FLAG_GRANT_READ_URI_PERMISSION)
-            }, if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
+            },
                 PendingIntent.FLAG_IMMUTABLE or PendingIntent.FLAG_CANCEL_CURRENT
-            } else {
-                PendingIntent.FLAG_CANCEL_CURRENT
-            }
         )
 
         val pendingDeleteIntent =  PendingIntent.getService(this,
@@ -212,11 +209,8 @@ class AttachmentFileNotificationService: LockNotificationService() {
                 Intent(this, AttachmentFileNotificationService::class.java).apply {
                     // No action to delete the service
                     putExtra(FILE_URI_KEY, attachmentNotification.uri)
-                }, if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
+                },
                 PendingIntent.FLAG_IMMUTABLE or PendingIntent.FLAG_CANCEL_CURRENT
-            } else {
-                PendingIntent.FLAG_CANCEL_CURRENT
-            }
         )
 
         val fileName = attachmentNotification.uri.getDocumentFile(this)?.name

--- a/app/src/main/java/com/kunzisoft/keepass/services/ClipboardEntryNotificationService.kt
+++ b/app/src/main/java/com/kunzisoft/keepass/services/ClipboardEntryNotificationService.kt
@@ -121,11 +121,7 @@ class ClipboardEntryNotificationService : LockNotificationService() {
         }
         return PendingIntent.getService(
             this, 0, copyIntent,
-            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
-                PendingIntent.FLAG_IMMUTABLE or PendingIntent.FLAG_UPDATE_CURRENT
-            } else {
-                PendingIntent.FLAG_UPDATE_CURRENT
-            }
+            PendingIntent.FLAG_IMMUTABLE or PendingIntent.FLAG_UPDATE_CURRENT
         )
     }
 
@@ -185,11 +181,7 @@ class ClipboardEntryNotificationService : LockNotificationService() {
             cleanIntent.action = ACTION_CLEAN_CLIPBOARD
             val cleanPendingIntent = PendingIntent.getService(
                 this, 0, cleanIntent,
-                if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
-                    PendingIntent.FLAG_IMMUTABLE or PendingIntent.FLAG_UPDATE_CURRENT
-                } else {
-                    PendingIntent.FLAG_UPDATE_CURRENT
-                }
+                PendingIntent.FLAG_IMMUTABLE or PendingIntent.FLAG_UPDATE_CURRENT
             )
             builder.setDeleteIntent(cleanPendingIntent)
 

--- a/app/src/main/java/com/kunzisoft/keepass/services/DatabaseTaskNotificationService.kt
+++ b/app/src/main/java/com/kunzisoft/keepass/services/DatabaseTaskNotificationService.kt
@@ -549,21 +549,13 @@ open class DatabaseTaskNotificationService : LockNotificationService(), Progress
                         this,
                         0,
                         Intent(this, GroupActivity::class.java),
-                        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
-                            PendingIntent.FLAG_IMMUTABLE or PendingIntent.FLAG_UPDATE_CURRENT
-                        } else {
-                            PendingIntent.FLAG_UPDATE_CURRENT
-                        }
+                        PendingIntent.FLAG_IMMUTABLE or PendingIntent.FLAG_UPDATE_CURRENT
                     )
                     val pendingDeleteIntent = PendingIntent.getBroadcast(
                         this,
                         4576,
                         Intent(LOCK_ACTION),
-                        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
-                            PendingIntent.FLAG_IMMUTABLE
-                        } else {
-                            0
-                        }
+                        PendingIntent.FLAG_IMMUTABLE
                     )
                     // Add actions in notifications
                     notificationBuilder.apply {

--- a/app/src/main/java/com/kunzisoft/keepass/services/KeyboardEntryNotificationService.kt
+++ b/app/src/main/java/com/kunzisoft/keepass/services/KeyboardEntryNotificationService.kt
@@ -96,11 +96,7 @@ class KeyboardEntryNotificationService : LockNotificationService() {
             action = ACTION_CLEAN_KEYBOARD_ENTRY
         }
         pendingDeleteIntent = PendingIntent.getService(this, 0, deleteIntent,
-            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
-                PendingIntent.FLAG_IMMUTABLE or PendingIntent.FLAG_UPDATE_CURRENT
-            } else {
-                PendingIntent.FLAG_UPDATE_CURRENT
-            }
+            PendingIntent.FLAG_IMMUTABLE or PendingIntent.FLAG_UPDATE_CURRENT
         )
 
         val builder = buildNewNotification()

--- a/app/src/main/java/com/kunzisoft/keepass/services/NotificationService.kt
+++ b/app/src/main/java/com/kunzisoft/keepass/services/NotificationService.kt
@@ -40,17 +40,15 @@ abstract class NotificationService : Service() {
 
         notificationManager = NotificationManagerCompat.from(this)
 
-        // Create notification channel for Oreo+
-        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
-            if (notificationManager?.getNotificationChannel(retrieveChannelId()) == null) {
-                val channel = NotificationChannel(retrieveChannelId(),
-                        retrieveChannelName(),
-                        NotificationManager.IMPORTANCE_DEFAULT).apply {
-                    enableVibration(false)
-                    setSound(null, null)
-                }
-                notificationManager?.createNotificationChannel(channel)
+        // Create notification channel
+        if (notificationManager?.getNotificationChannel(retrieveChannelId()) == null) {
+            val channel = NotificationChannel(retrieveChannelId(),
+                    retrieveChannelName(),
+                    NotificationManager.IMPORTANCE_DEFAULT).apply {
+                enableVibration(false)
+                setSound(null, null)
             }
+            notificationManager?.createNotificationChannel(channel)
         }
 
         // Get the color

--- a/app/src/main/java/com/kunzisoft/keepass/settings/NestedAppSettingsFragment.kt
+++ b/app/src/main/java/com/kunzisoft/keepass/settings/NestedAppSettingsFragment.kt
@@ -118,60 +118,53 @@ class NestedAppSettingsFragment : NestedSettingsFragment() {
         setPreferencesFromResource(R.xml.preferences_form_filling, rootKey)
 
         activity?.let { activity ->
-            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
-                val autoFillEnablePreference: TwoStatePreference? = findPreference(getString(R.string.settings_autofill_enable_key))
-                activity.getSystemService(AutofillManager::class.java)?.let { autofillManager ->
-                    if (autofillManager.hasEnabledAutofillServices())
-                        autoFillEnablePreference?.isChecked = autofillManager.hasEnabledAutofillServices()
+            val autoFillEnablePreference: TwoStatePreference? = findPreference(getString(R.string.settings_autofill_enable_key))
+            activity.getSystemService(AutofillManager::class.java)?.let { autofillManager ->
+                if (autofillManager.hasEnabledAutofillServices())
+                    autoFillEnablePreference?.isChecked = autofillManager.hasEnabledAutofillServices()
 
-                    autoFillEnablePreference?.onPreferenceClickListener =
-                        object : Preference.OnPreferenceClickListener {
-                            @RequiresApi(api = Build.VERSION_CODES.O)
-                            override fun onPreferenceClick(preference: Preference): Boolean {
-                                if ((preference as TwoStatePreference).isChecked) {
-                                    try {
-                                        enableService()
-                                    } catch (e: ActivityNotFoundException) {
-                                        val error =
-                                            getString(R.string.error_autofill_enable_service)
-                                        preference.isChecked = false
-                                        Log.d(javaClass.name, error, e)
-                                        Toast.makeText(context, error, Toast.LENGTH_SHORT).show()
-                                    }
-
-                                } else {
-                                    disableService()
+                autoFillEnablePreference?.onPreferenceClickListener =
+                    object : Preference.OnPreferenceClickListener {
+                        override fun onPreferenceClick(preference: Preference): Boolean {
+                            if ((preference as TwoStatePreference).isChecked) {
+                                try {
+                                    enableService()
+                                } catch (e: ActivityNotFoundException) {
+                                    val error =
+                                        getString(R.string.error_autofill_enable_service)
+                                    preference.isChecked = false
+                                    Log.d(javaClass.name, error, e)
+                                    Toast.makeText(context, error, Toast.LENGTH_SHORT).show()
                                 }
-                                return false
+
+                            } else {
+                                disableService()
                             }
+                            return false
+                        }
 
-                            @RequiresApi(api = Build.VERSION_CODES.O)
-                            private fun disableService() {
-                                if (autofillManager.hasEnabledAutofillServices()) {
-                                    autofillManager.disableAutofillServices()
-                                } else {
-                                    Log.d(javaClass.name, "Autofill service already disabled.")
-                                }
-                            }
-
-                            @RequiresApi(api = Build.VERSION_CODES.O)
-                            @Throws(ActivityNotFoundException::class)
-                            private fun enableService() {
-                                if (!autofillManager.hasEnabledAutofillServices()) {
-                                    val intent =
-                                        Intent(Settings.ACTION_REQUEST_SET_AUTOFILL_SERVICE)
-                                    intent.data =
-                                        Uri.parse("package:com.kunzisoft.keepass.autofill.KeeAutofillService")
-                                    Log.d(javaClass.name, "Autofill enable service: intent=$intent")
-                                    startActivity(intent)
-                                } else {
-                                    Log.d(javaClass.name, "Autofill service already enabled.")
-                                }
+                        private fun disableService() {
+                            if (autofillManager.hasEnabledAutofillServices()) {
+                                autofillManager.disableAutofillServices()
+                            } else {
+                                Log.d(javaClass.name, "Autofill service already disabled.")
                             }
                         }
-                }
-            } else {
-                findPreference<Preference>(getString(R.string.autofill_key))?.isVisible = false
+
+                        @Throws(ActivityNotFoundException::class)
+                        private fun enableService() {
+                            if (!autofillManager.hasEnabledAutofillServices()) {
+                                val intent =
+                                    Intent(Settings.ACTION_REQUEST_SET_AUTOFILL_SERVICE)
+                                intent.data =
+                                    Uri.parse("package:com.kunzisoft.keepass.autofill.KeeAutofillService")
+                                Log.d(javaClass.name, "Autofill enable service: intent=$intent")
+                                startActivity(intent)
+                            } else {
+                                Log.d(javaClass.name, "Autofill service already enabled.")
+                            }
+                        }
+                    }
             }
         }
 
@@ -250,11 +243,9 @@ class NestedAppSettingsFragment : NestedSettingsFragment() {
             val autoOpenPromptPreference: TwoStatePreference? = findPreference(getString(R.string.biometric_auto_open_prompt_key))
             val tempAdvancedUnlockPreference: TwoStatePreference? = findPreference(getString(R.string.temp_advanced_unlock_enable_key))
 
-            val biometricUnlockSupported = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
-                AdvancedUnlockManager.biometricUnlockSupported(activity)
-            } else false
+            val biometricUnlockSupported =
+                    AdvancedUnlockManager.biometricUnlockSupported(activity)
             biometricUnlockEnablePreference?.apply {
-                // False if under Marshmallow
                 if (!biometricUnlockSupported) {
                     isChecked = false
                     setOnPreferenceClickListener { preference ->
@@ -295,9 +286,8 @@ class NestedAppSettingsFragment : NestedSettingsFragment() {
                 }
             }
 
-            val deviceCredentialUnlockSupported = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
-                AdvancedUnlockManager.deviceCredentialUnlockSupported(activity)
-            } else false
+            val deviceCredentialUnlockSupported =
+                    AdvancedUnlockManager.deviceCredentialUnlockSupported(activity)
             deviceCredentialUnlockEnablePreference?.apply {
                 // Biometric unlock already checked
                 if (biometricUnlockEnablePreference?.isChecked == true)
@@ -394,7 +384,7 @@ class NestedAppSettingsFragment : NestedSettingsFragment() {
             ) { _, _ ->
                 validate?.invoke()
                 warningAlertDialog?.setOnDismissListener(null)
-                if (deleteKeys && Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
+                if (deleteKeys) {
                     AdvancedUnlockManager.deleteAllEntryKeysInKeystoreForBiometric(activity)
                 }
             }
@@ -527,12 +517,10 @@ class NestedAppSettingsFragment : NestedSettingsFragment() {
     override fun onResume() {
         super.onResume()
         activity?.let { activity ->
-            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
-                findPreference<TwoStatePreference?>(getString(R.string.settings_autofill_enable_key))?.let { autoFillEnablePreference ->
-                    val autofillManager = activity.getSystemService(AutofillManager::class.java)
-                    autoFillEnablePreference.isChecked = autofillManager != null
-                            && autofillManager.hasEnabledAutofillServices()
-                }
+            findPreference<TwoStatePreference?>(getString(R.string.settings_autofill_enable_key))?.let { autoFillEnablePreference ->
+                val autofillManager = activity.getSystemService(AutofillManager::class.java)
+                autoFillEnablePreference.isChecked = autofillManager != null
+                        && autofillManager.hasEnabledAutofillServices()
             }
         }
     }

--- a/app/src/main/java/com/kunzisoft/keepass/settings/PreferencesUtil.kt
+++ b/app/src/main/java/com/kunzisoft/keepass/settings/PreferencesUtil.kt
@@ -499,11 +499,9 @@ object PreferencesUtil {
         val prefs = PreferenceManager.getDefaultSharedPreferences(context)
         return prefs.getBoolean(context.getString(R.string.biometric_unlock_enable_key),
             context.resources.getBoolean(R.bool.biometric_unlock_enable_default))
-                && (if (android.os.Build.VERSION.SDK_INT >= android.os.Build.VERSION_CODES.M) {
-            AdvancedUnlockManager.biometricUnlockSupported(context)
-        } else {
-            false
-        })
+                && (
+                AdvancedUnlockManager.biometricUnlockSupported(context)
+                )
     }
 
     fun isDeviceCredentialUnlockEnable(context: Context): Boolean {

--- a/app/src/main/java/com/kunzisoft/keepass/timeout/ClipboardHelper.kt
+++ b/app/src/main/java/com/kunzisoft/keepass/timeout/ClipboardHelper.kt
@@ -66,10 +66,8 @@ class ClipboardHelper(context: Context) {
 
     fun copyToClipboard(label: String, value: String, sensitive: Boolean = false) {
         getClipboardManager()?.setPrimaryClip(ClipData.newPlainText(DEFAULT_LABEL, value).apply {
-            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.N) {
-                description.extras = PersistableBundle().apply {
-                    putBoolean("android.content.extra.IS_SENSITIVE", sensitive)
-                }
+            description.extras = PersistableBundle().apply {
+                putBoolean("android.content.extra.IS_SENSITIVE", sensitive)
             }
         })
         if (label.isNotEmpty() && Build.VERSION.SDK_INT < Build.VERSION_CODES.S_V2) {
@@ -86,11 +84,7 @@ class ClipboardHelper(context: Context) {
 
     fun cleanClipboard() {
         try {
-            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.P) {
-                getClipboardManager()?.clearPrimaryClip()
-            } else {
-                copyToClipboard(DEFAULT_LABEL, "")
-            }
+            getClipboardManager()?.clearPrimaryClip()
         } catch (e: Exception) {
             Log.e("ClipboardHelper", "Unable to clean the clipboard", e)
         }

--- a/app/src/main/java/com/kunzisoft/keepass/timeout/TimeoutHelper.kt
+++ b/app/src/main/java/com/kunzisoft/keepass/timeout/TimeoutHelper.kt
@@ -45,11 +45,7 @@ object TimeoutHelper {
         return PendingIntent.getBroadcast(context.applicationContext,
             REQUEST_ID,
             Intent(LOCK_ACTION),
-            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
-                PendingIntent.FLAG_IMMUTABLE or PendingIntent.FLAG_CANCEL_CURRENT
-            } else {
-                PendingIntent.FLAG_CANCEL_CURRENT
-            }
+            PendingIntent.FLAG_IMMUTABLE or PendingIntent.FLAG_CANCEL_CURRENT
         )
     }
 
@@ -65,23 +61,15 @@ object TimeoutHelper {
                 (context.applicationContext.getSystemService(Context.ALARM_SERVICE) as AlarmManager?)?.let { alarmManager ->
                     val triggerTime = System.currentTimeMillis() + timeout
                     Log.d(TAG, "TimeoutHelper start")
-                    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.KITKAT) {
-                        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S
-                            && !alarmManager.canScheduleExactAlarms()) {
-                            alarmManager.set(
-                                AlarmManager.RTC,
-                                triggerTime,
-                                getLockPendingIntent(context)
-                            )
-                        } else {
-                            alarmManager.setExact(
-                                AlarmManager.RTC,
-                                triggerTime,
-                                getLockPendingIntent(context)
-                            )
-                        }
-                    } else {
+                    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S
+                        && !alarmManager.canScheduleExactAlarms()) {
                         alarmManager.set(
+                            AlarmManager.RTC,
+                            triggerTime,
+                            getLockPendingIntent(context)
+                        )
+                    } else {
+                        alarmManager.setExact(
                             AlarmManager.RTC,
                             triggerTime,
                             getLockPendingIntent(context)

--- a/app/src/main/java/com/kunzisoft/keepass/utils/BroadcastAction.kt
+++ b/app/src/main/java/com/kunzisoft/keepass/utils/BroadcastAction.kt
@@ -65,35 +65,23 @@ class LockReceiver(var lockAction: () -> Unit) : BroadcastReceiver() {
                                 Intent(intent).apply {
                                     action = LOCK_ACTION
                                 },
-                                if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
-                                    PendingIntent.FLAG_IMMUTABLE
-                                } else {
-                                    0
-                                }
+                                PendingIntent.FLAG_IMMUTABLE
                             )
                             // Launch the effective action after a small time
                             val first: Long = System.currentTimeMillis() + context.getString(R.string.timeout_screen_off).toLong()
                             (context.getSystemService(ALARM_SERVICE) as AlarmManager?)?.let { alarmManager ->
-                                if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.KITKAT) {
-                                    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S
-                                        && !alarmManager.canScheduleExactAlarms()) {
-                                        alarmManager.set(
-                                            AlarmManager.RTC_WAKEUP,
-                                            first,
-                                            mLockPendingIntent
-                                        )
-                                    } else {
-                                        alarmManager.setExact(
-                                            AlarmManager.RTC_WAKEUP,
-                                            first,
-                                            mLockPendingIntent
-                                        )
-                                    }
-                                } else {
+                                if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S
+                                    && !alarmManager.canScheduleExactAlarms()) {
                                     alarmManager.set(
                                         AlarmManager.RTC_WAKEUP,
                                         first,
-                                        mLockPendingIntent
+                                        mLockPendingIntent!!
+                                    )
+                                } else {
+                                    alarmManager.setExact(
+                                        AlarmManager.RTC_WAKEUP,
+                                        first,
+                                        mLockPendingIntent!!
                                     )
                                 }
                             }
@@ -122,7 +110,7 @@ class LockReceiver(var lockAction: () -> Unit) : BroadcastReceiver() {
     private fun cancelLockPendingIntent(context: Context) {
         mLockPendingIntent?.let {
             val alarmManager = context.getSystemService(ALARM_SERVICE) as AlarmManager?
-            alarmManager?.cancel(mLockPendingIntent)
+            alarmManager?.cancel(mLockPendingIntent!!)
             mLockPendingIntent = null
         }
     }

--- a/app/src/main/java/com/kunzisoft/keepass/utils/KeyboardUtil.kt
+++ b/app/src/main/java/com/kunzisoft/keepass/utils/KeyboardUtil.kt
@@ -37,14 +37,7 @@ object KeyboardUtil {
         var imeManager: InputMethodManager? = null
         try {
             imeManager = ContextCompat.getSystemService(this, InputMethodManager::class.java)
-            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.P) {
-                switchToPreviousInputMethod()
-            } else {
-                @Suppress("DEPRECATION")
-                window.window?.let { window ->
-                    imeManager?.switchToLastInputMethod(window.attributes.token)
-                }
-            }
+            switchToPreviousInputMethod()
         } catch (e: Exception) {
             Log.e(TAG, "Unable to switch to the previous IME", e)
             imeManager?.showInputMethodPicker()

--- a/app/src/main/java/com/kunzisoft/keepass/view/AdvancedUnlockInfoView.kt
+++ b/app/src/main/java/com/kunzisoft/keepass/view/AdvancedUnlockInfoView.kt
@@ -30,7 +30,6 @@ import androidx.annotation.RequiresApi
 import androidx.annotation.StringRes
 import com.kunzisoft.keepass.R
 
-@RequiresApi(api = Build.VERSION_CODES.M)
 class AdvancedUnlockInfoView @JvmOverloads constructor(context: Context,
                                                        attrs: AttributeSet? = null,
                                                        defStyle: Int = 0)

--- a/app/src/main/java/com/kunzisoft/keepass/view/TemplateAbstractView.kt
+++ b/app/src/main/java/com/kunzisoft/keepass/view/TemplateAbstractView.kt
@@ -67,12 +67,6 @@ abstract class TemplateAbstractView<
         foregroundColorButton = findViewById(R.id.template_foreground_color_button)
         titleContainerView = findViewById(R.id.template_title_container)
         templateContainerView = findViewById(R.id.template_fields_container)
-        // To fix card view margin below Marshmallow
-        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.M) {
-            val paddingVertical = resources.getDimensionPixelSize(R.dimen.card_view_margin_vertical)
-            val paddingHorizontal = resources.getDimensionPixelSize(R.dimen.card_view_margin_horizontal)
-            templateContainerView.setPadding(paddingHorizontal, paddingVertical, paddingHorizontal, paddingVertical)
-        }
         customFieldsContainerView = findViewById(R.id.custom_fields_container)
         notReferencedFieldsContainerView = findViewById(R.id.not_referenced_fields_container)
     }

--- a/app/src/main/java/com/kunzisoft/keepass/view/TemplateEditView.kt
+++ b/app/src/main/java/com/kunzisoft/keepass/view/TemplateEditView.kt
@@ -119,9 +119,7 @@ class TemplateEditView @JvmOverloads constructor(context: Context,
                 setMaxChars(templateAttribute.options.getNumberChars())
                 setMaxLines(templateAttribute.options.getNumberLines())
                 setActionClick(templateAttribute, field, this)
-                if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
-                    importantForAutofill = View.IMPORTANT_FOR_AUTOFILL_NO
-                }
+                importantForAutofill = View.IMPORTANT_FOR_AUTOFILL_NO
             }
         }
     }
@@ -133,9 +131,7 @@ class TemplateEditView @JvmOverloads constructor(context: Context,
                 setItems(templateAttribute.options.getListItems())
                 default = templateAttribute.default
                 setActionClick(templateAttribute, field, this)
-                if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
-                    importantForAutofill = View.IMPORTANT_FOR_AUTOFILL_NO
-                }
+                importantForAutofill = View.IMPORTANT_FOR_AUTOFILL_NO
             }
         }
     }

--- a/app/src/main/java/com/kunzisoft/keepass/view/TextEditFieldView.kt
+++ b/app/src/main/java/com/kunzisoft/keepass/view/TextEditFieldView.kt
@@ -52,13 +52,9 @@ class TextEditFieldView @JvmOverloads constructor(context: Context,
                 LayoutParams.MATCH_PARENT,
                 LayoutParams.WRAP_CONTENT)
         inputType = EditorInfo.TYPE_TEXT_FLAG_NO_SUGGESTIONS
-        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
-            imeOptions = EditorInfo.IME_FLAG_NO_PERSONALIZED_LEARNING
-            importantForAutofill = IMPORTANT_FOR_AUTOFILL_NO
-        }
-        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.JELLY_BEAN) {
-            importantForAccessibility = IMPORTANT_FOR_ACCESSIBILITY_NO
-        }
+        imeOptions = EditorInfo.IME_FLAG_NO_PERSONALIZED_LEARNING
+        importantForAutofill = IMPORTANT_FOR_AUTOFILL_NO
+        importantForAccessibility = IMPORTANT_FOR_ACCESSIBILITY_NO
         maxLines = 1
     }
     private var actionImageButton = AppCompatImageButton(
@@ -72,9 +68,7 @@ class TextEditFieldView @JvmOverloads constructor(context: Context,
                     resources.displayMetrics
             ).toInt()
             it.addRule(ALIGN_PARENT_RIGHT)
-            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.JELLY_BEAN_MR1) {
-                it.addRule(ALIGN_PARENT_END)
-            }
+            it.addRule(ALIGN_PARENT_END)
         }
         visibility = View.GONE
         contentDescription = context.getString(R.string.menu_edit)
@@ -108,9 +102,7 @@ class TextEditFieldView @JvmOverloads constructor(context: Context,
             id = labelViewId
             layoutParams = (layoutParams as LayoutParams?).also {
                 it?.addRule(LEFT_OF, actionImageButtonId)
-                if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.JELLY_BEAN_MR1) {
-                    it?.addRule(START_OF, actionImageButtonId)
-                }
+                it?.addRule(START_OF, actionImageButtonId)
             }
         }
         valueView.apply {

--- a/app/src/main/java/com/kunzisoft/keepass/view/TextFieldView.kt
+++ b/app/src/main/java/com/kunzisoft/keepass/view/TextFieldView.kt
@@ -68,13 +68,11 @@ class TextFieldView @JvmOverloads constructor(context: Context,
                 4f,
                 resources.displayMetrics
             ).toInt()
-            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.JELLY_BEAN_MR1) {
-                it.marginStart = TypedValue.applyDimension(
-                    TypedValue.COMPLEX_UNIT_DIP,
-                    4f,
-                    resources.displayMetrics
-                ).toInt()
-            }
+            it.marginStart = TypedValue.applyDimension(
+                TypedValue.COMPLEX_UNIT_DIP,
+                4f,
+                resources.displayMetrics
+            ).toInt()
         }
     }
     private val valueView = AppCompatTextView(context).apply {
@@ -93,13 +91,11 @@ class TextFieldView @JvmOverloads constructor(context: Context,
                 8f,
                 resources.displayMetrics
             ).toInt()
-            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.JELLY_BEAN_MR1) {
-                it.marginStart = TypedValue.applyDimension(
-                    TypedValue.COMPLEX_UNIT_DIP,
-                    8f,
-                    resources.displayMetrics
-                ).toInt()
-            }
+            it.marginStart = TypedValue.applyDimension(
+                TypedValue.COMPLEX_UNIT_DIP,
+                8f,
+                resources.displayMetrics
+            ).toInt()
         }
         setTextIsSelectable(true)
     }
@@ -133,9 +129,7 @@ class TextFieldView @JvmOverloads constructor(context: Context,
             id = copyButtonId
             layoutParams = (layoutParams as LayoutParams?).also {
                 it?.addRule(ALIGN_PARENT_RIGHT)
-                if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.JELLY_BEAN_MR1) {
-                    it?.addRule(ALIGN_PARENT_END)
-                }
+                it?.addRule(ALIGN_PARENT_END)
             }
         }
         showButton.apply {
@@ -143,14 +137,10 @@ class TextFieldView @JvmOverloads constructor(context: Context,
             layoutParams = (layoutParams as LayoutParams?).also {
                 if (copyButton.isVisible) {
                     it?.addRule(LEFT_OF, copyButtonId)
-                    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.JELLY_BEAN_MR1) {
-                        it?.addRule(START_OF, copyButtonId)
-                    }
+                    it?.addRule(START_OF, copyButtonId)
                 } else {
                     it?.addRule(ALIGN_PARENT_RIGHT)
-                    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.JELLY_BEAN_MR1) {
-                        it?.addRule(ALIGN_PARENT_END)
-                    }
+                    it?.addRule(ALIGN_PARENT_END)
                 }
             }
         }
@@ -158,18 +148,14 @@ class TextFieldView @JvmOverloads constructor(context: Context,
             id = labelViewId
             layoutParams = (layoutParams as LayoutParams?).also {
                 it?.addRule(LEFT_OF, showButtonId)
-                if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.JELLY_BEAN_MR1) {
-                    it?.addRule(START_OF, showButtonId)
-                }
+                it?.addRule(START_OF, showButtonId)
             }
         }
         valueView.apply {
             id = valueViewId
             layoutParams = (layoutParams as LayoutParams?).also {
                 it?.addRule(LEFT_OF, showButtonId)
-                if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.JELLY_BEAN_MR1) {
-                    it?.addRule(START_OF, showButtonId)
-                }
+                it?.addRule(START_OF, showButtonId)
                 it?.addRule(BELOW, labelViewId)
             }
         }

--- a/app/src/main/java/com/kunzisoft/keepass/view/TextSelectFieldView.kt
+++ b/app/src/main/java/com/kunzisoft/keepass/view/TextSelectFieldView.kt
@@ -47,13 +47,9 @@ class TextSelectFieldView @JvmOverloads constructor(context: Context,
             LayoutParams.MATCH_PARENT,
             LayoutParams.WRAP_CONTENT)
         inputType = EditorInfo.TYPE_TEXT_FLAG_NO_SUGGESTIONS
-        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
-            imeOptions = EditorInfo.IME_FLAG_NO_PERSONALIZED_LEARNING
-            importantForAutofill = IMPORTANT_FOR_AUTOFILL_NO
-        }
-        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.JELLY_BEAN) {
-            importantForAccessibility = IMPORTANT_FOR_ACCESSIBILITY_NO
-        }
+        imeOptions = EditorInfo.IME_FLAG_NO_PERSONALIZED_LEARNING
+        importantForAutofill = IMPORTANT_FOR_AUTOFILL_NO
+        importantForAccessibility = IMPORTANT_FOR_ACCESSIBILITY_NO
         val drawable = ContextCompat.getDrawable(context, R.drawable.ic_arrow_down_white_24dp)
             ?.apply {
                 mutate().colorFilter = BlendModeColorFilterCompat
@@ -65,14 +61,12 @@ class TextSelectFieldView @JvmOverloads constructor(context: Context,
             drawable,
             null
         )
-        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.JELLY_BEAN_MR1) {
-            setCompoundDrawablesRelativeWithIntrinsicBounds(
-                null,
-                null,
-                drawable,
-                null
-            )
-        }
+        setCompoundDrawablesRelativeWithIntrinsicBounds(
+            null,
+            null,
+            drawable,
+            null
+        )
         isFocusable = false
         inputType = InputType.TYPE_NULL
         maxLines = 1
@@ -94,9 +88,7 @@ class TextSelectFieldView @JvmOverloads constructor(context: Context,
                     resources.displayMetrics
             ).toInt()
             it.addRule(ALIGN_PARENT_RIGHT)
-            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.JELLY_BEAN_MR1) {
-                it.addRule(ALIGN_PARENT_END)
-            }
+            it.addRule(ALIGN_PARENT_END)
         }
         visibility = View.GONE
         contentDescription = context.getString(R.string.menu_edit)
@@ -132,18 +124,14 @@ class TextSelectFieldView @JvmOverloads constructor(context: Context,
             id = labelViewId
             layoutParams = (layoutParams as LayoutParams?).also {
                 it?.addRule(LEFT_OF, actionImageButtonId)
-                if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.JELLY_BEAN_MR1) {
-                    it?.addRule(START_OF, actionImageButtonId)
-                }
+                it?.addRule(START_OF, actionImageButtonId)
             }
         }
         valueSpinnerView.apply {
             id = valueViewId
             layoutParams = (layoutParams as LayoutParams?).also {
                 it?.addRule(LEFT_OF, actionImageButtonId)
-                if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.JELLY_BEAN_MR1) {
-                    it?.addRule(START_OF, actionImageButtonId)
-                }
+                it?.addRule(START_OF, actionImageButtonId)
                 it?.addRule(BELOW, labelViewId)
             }
         }

--- a/app/src/main/java/com/kunzisoft/keepass/view/ViewUtil.kt
+++ b/app/src/main/java/com/kunzisoft/keepass/view/ViewUtil.kt
@@ -256,7 +256,7 @@ fun CoordinatorLayout.showActionErrorIfNeeded(result: ActionRunnable.Result) {
 }
 
 fun Toolbar.changeControlColor(color: Int) {
-    val colorFilter = PorterDuffColorFilter(color, PorterDuff.Mode.SRC_ATOP);
+    val colorFilter = PorterDuffColorFilter(color, PorterDuff.Mode.SRC_ATOP)
     for (i in 0 until childCount) {
         val view: View = getChildAt(i)
         // Change the color of back button (or open drawer button).
@@ -303,8 +303,7 @@ fun CollapsingToolbarLayout.changeTitleColor(color: Int) {
 
 fun Activity.setTransparentNavigationBar(applyToStatusBar: Boolean = false, applyWindowInsets: () -> Unit) {
     // Only in portrait
-    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O_MR1
-        && resources.configuration.orientation == Configuration.ORIENTATION_PORTRAIT) {
+    if (resources.configuration.orientation == Configuration.ORIENTATION_PORTRAIT) {
         WindowCompat.setDecorFitsSystemWindows(window, false)
         this.window.navigationBarColor = ContextCompat.getColor(this, R.color.surface_selector)
         if (applyToStatusBar) {

--- a/build.gradle
+++ b/build.gradle
@@ -1,16 +1,16 @@
 // Top-level build file where you can add configuration options common to all sub-projects/modules.
 buildscript {
-    ext.kotlin_version = '1.8.20'
-    ext.android_core_version = '1.10.1'
+    ext.kotlin_version = '1.9.24'
+    ext.android_core_version = '1.13.1'
     ext.android_appcompat_version = '1.6.1'
-    ext.android_material_version = '1.9.0'
+    ext.android_material_version = '1.12.0'
     ext.android_test_version = '1.5.2'
     repositories {
         mavenCentral()
         google()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:7.4.2'
+        classpath 'com.android.tools.build:gradle:8.4.0'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
     }
 }

--- a/crypto/build.gradle
+++ b/crypto/build.gradle
@@ -5,13 +5,13 @@ plugins {
 
 android {
     namespace 'com.kunzisoft.encrypt'
-    compileSdkVersion 33
-    buildToolsVersion "33.0.2"
-    ndkVersion "21.4.7075529"
+    compileSdk 34
+    buildToolsVersion "34.0.0"
+    ndkVersion "26.3.11579264"
 
     defaultConfig {
-        minSdkVersion 15
-        targetSdkVersion 33
+        minSdk 29
+        targetSdk 33
         multiDexEnabled true
 
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"

--- a/database/build.gradle
+++ b/database/build.gradle
@@ -3,11 +3,11 @@ apply plugin: 'kotlin-android'
 
 android {
     namespace 'com.kunzisoft.keepass.database'
-    compileSdkVersion 33
-    buildToolsVersion "33.0.2"
+    compileSdk 34
+    buildToolsVersion "34.0.0"
 
     defaultConfig {
-        minSdkVersion 15
+        minSdk 29
         targetSdk 33
 
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
@@ -39,7 +39,7 @@ dependencies {
     // Time
     implementation 'joda-time:joda-time:2.10.13'
     // Apache Commons
-    implementation 'commons-io:commons-io:2.8.0'
+    implementation 'commons-io:commons-io:2.13.0'
     implementation 'commons-codec:commons-codec:1.15'
 
     implementation project(path: ':crypto')

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,7 @@
+android.defaults.buildfeatures.buildconfig=true
 android.enableJetifier=true
+android.nonFinalResIds=false
+android.nonTransitiveRClass=false
 android.useAndroidX=true
 kapt.incremental.apt=true
 org.gradle.jvmargs=-Xmx2048M

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.5.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.6-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/icon-pack/build.gradle
+++ b/icon-pack/build.gradle
@@ -3,12 +3,12 @@ apply plugin: 'kotlin-android'
 
 android {
     namespace 'com.kunzisoft.keepass.icon'
-    compileSdkVersion 33
-    buildToolsVersion '33.0.2'
+    compileSdk 34
+    buildToolsVersion '34.0.0'
 
     defaultConfig {
-        minSdkVersion 14
-        targetSdkVersion 33
+        minSdk 29
+        targetSdk 33
     }
 
     compileOptions {

--- a/icon-pack/classic/build.gradle
+++ b/icon-pack/classic/build.gradle
@@ -2,12 +2,12 @@ apply plugin: 'com.android.library'
 
 android {
     namespace 'com.kunzisoft.keepass.icon.classic'
-    compileSdkVersion 33
-    buildToolsVersion '33.0.2'
+    compileSdk 34
+    buildToolsVersion '34.0.0'
 
     defaultConfig {
-        minSdkVersion 14
-        targetSdkVersion 33
+        minSdk 29
+        targetSdk 33
     }
 
     resourcePrefix 'classic_'

--- a/icon-pack/material/build.gradle
+++ b/icon-pack/material/build.gradle
@@ -2,12 +2,12 @@ apply plugin: 'com.android.library'
 
 android {
     namespace 'com.kunzisoft.keepass.icon.material'
-    compileSdkVersion 33
-    buildToolsVersion '33.0.2'
+    compileSdk 34
+    buildToolsVersion '34.0.0'
 
     defaultConfig {
-        minSdkVersion 14
-        targetSdkVersion 33
+        minSdk 29
+        targetSdk 33
     }
 
     resourcePrefix 'material_'


### PR DESCRIPTION
This controversal PR is mostly a small maintenance one, but with a couple of big changes when it comes to compatibility with Android versions below Quincetart (10).

Many of the project dependencies have been upgraded in preparation to targeting SDK 34 (14).

The minSDK has been bumped to 29, and lots of applicable obselete version checking and handling code has been removed.

While mostly a non-functional change that decreases compatibility with older Android releases. Some of the upgraded dependencies now don't support minSDKs below 21 (5) officially. Many apps in the security and privacy space that are built for Android are also receiving a degree of pressure to support more secure Android releases only, from their users.
https://github.com/Kunzisoft/KeePassDX/issues/1730
https://github.com/mollyim/mollyim-android/issues/108

As for why Android 10 being the cutoff. It seemed to be the best balance. Any more aggressive, and major percentages of the KeePassDX userbase could be potentially left out.

Samples from across the internet, such as the Android Studio SDK distribution, generally show that a small percentage of the entire Android userbase (while still millions of people) who use these older, insecure versions, are migrating away from them. Making supporting them for longer, make less sense as time goes on and ultimately holds back the project.
![image](https://github.com/Kunzisoft/KeePassDX/assets/116324840/38f972b6-da7c-4d00-9ea2-feb8718edba1)


Review the commits and please leave feedback if anything blocks this PR in particular and/or if other development plans are occuring. Thank you. :)
