### PR TITLE
fix: inline suggestions in keyboard only show ''Select entry''

### DIFF
--- a/app/src/main/java/com/kunzisoft/keepass/autofill/AutofillHelper.kt
+++ b/app/src/main/java/com/kunzisoft/keepass/autofill/AutofillHelper.kt
@@ -60,6 +60,7 @@ import com.kunzisoft.keepass.settings.AutofillSettingsActivity
 import com.kunzisoft.keepass.settings.PreferencesUtil
 import com.kunzisoft.keepass.utils.LOCK_ACTION
 import com.kunzisoft.keepass.utils.getParcelableExtraCompat
+import kotlin.math.min
 
 
 @RequiresApi(api = Build.VERSION_CODES.O)
@@ -321,10 +322,11 @@ object AutofillHelper {
             val inlinePresentationSpecs = inlineSuggestionsRequest.inlinePresentationSpecs
             val maxSuggestion = inlineSuggestionsRequest.maxSuggestionCount
 
-            if (positionItem <= maxSuggestion - 1
-                && inlinePresentationSpecs.size > positionItem
-            ) {
-                val inlinePresentationSpec = inlinePresentationSpecs[positionItem]
+            if (positionItem <= maxSuggestion - 1) {
+
+                // If positionItem is larger than the number of specs in the list, then
+                // the last spec is used for the remainder of the suggestions
+                val inlinePresentationSpec = inlinePresentationSpecs[min(positionItem, inlinePresentationSpecs.size - 1)]
 
                 // Make sure that the IME spec claims support for v1 UI template.
                 val imeStyle = inlinePresentationSpec.style


### PR DESCRIPTION
Refer to the inline suggestions implementation of [Bitwarden](https://github.com/bitwarden/mobile/blob/02f5936fce9bcfde961e62ad57ebf54f159ae078/src/App/Platforms/Android/Autofill/AutofillHelpers.cs#L217-L219) and [Keepass2Android](https://github.com/PhilippC/keepass2android/blob/32d3abf5d6b2506102e0761997ed2d44ff92cae1/src/keepass2android/services/AutofillBase/AutofillHelper.cs#L236-L239), when the number of entries exceeds the number of specs in the `inlineSuggestionsRequest`, they will put all remaining entries into the last spec.

While keepassdx detects an out-of-bounds, it discards the remaining entries. Refer to [fcitx5-for-android](https://github.com/fcitx5-android/fcitx5-android/blob/1865b15fe46cadd1265b5b8d400ed11b64504d05/app/src/main/java/org/fcitx/fcitx5/android/input/FcitxInputMethodService.kt#L774), the `inlineSuggestionsRequest` it sends has only one spec, so only ''Select entry'' will be displayed.

This should also work for other keyboards that send `inlineSuggestionsRequest` with just a spec.

