### PR TITLE
Use local date/time in filename for saving a copy of the database

### DIFF
--- a/app/src/main/java/com/kunzisoft/keepass/activities/GroupActivity.kt
+++ b/app/src/main/java/com/kunzisoft/keepass/activities/GroupActivity.kt
@@ -116,7 +116,7 @@ import com.kunzisoft.keepass.view.showActionErrorIfNeeded
 import com.kunzisoft.keepass.view.updateLockPaddingLeft
 import com.kunzisoft.keepass.viewmodels.GroupEditViewModel
 import com.kunzisoft.keepass.viewmodels.GroupViewModel
-import org.joda.time.Instant
+import org.joda.time.LocalDateTime
 
 
 class GroupActivity : DatabaseLockActivity(),
@@ -343,7 +343,7 @@ class GroupActivity : DatabaseLockActivity(),
                         mExternalFileHelper?.createDocument(
                             getString(R.string.database_file_name_default) +
                                     "_" +
-                                    Instant.now().toString() +
+                                    LocalDateTime.now().toString() +
                                     mDatabase?.defaultFileExtension)
                     }
                     R.id.menu_lock_all -> {


### PR DESCRIPTION
When trying to save a copy of the database, use the local time instead of UTC as a proposal for the filename. Fixes #1981