### PR TITLE
Fix OTP code alignment in the main screen

### DIFF
--- a/app/src/main/res/layout/item_list_nodes_entry.xml
+++ b/app/src/main/res/layout/item_list_nodes_entry.xml
@@ -125,8 +125,7 @@
                 android:paddingStart="8dp"
                 android:paddingLeft="8dp"
                 android:paddingEnd="4dp"
-                android:paddingRight="4dp"
-                android:paddingVertical="4dp">
+                android:paddingRight="4dp">
 
                 <TextView
                     android:id="@+id/node_otp_token"


### PR DESCRIPTION
The alignment of the OTP code is wrong on the main screen when usernames are hidden. Instead of it being at the vertical center point of the item, the code resides on the bottom as you can see from the picture(s) below. The first picture indicates what it looks like right now with the incorrect alignment. On the second picture you can see what it looks like with this commit applied.

![before](https://github.com/user-attachments/assets/a0a30c16-e8db-4575-b7fa-6866c326ac5f)
![after](https://github.com/user-attachments/assets/4501b7c7-fdd6-49fd-9a9e-8e49c8415e88)