### PR TITLE
Fix for "Can't Show/Hide Key During Set Up of OTP While Error Message Of Bad Format Is Active" #2048

### DIFF
--- a/app/src/main/java/com/kunzisoft/keepass/activities/dialogs/SetOTPDialogFragment.kt
+++ b/app/src/main/java/com/kunzisoft/keepass/activities/dialogs/SetOTPDialogFragment.kt
@@ -314,7 +314,6 @@ class SetOTPDialogFragment : DatabaseDialogFragment() {
         otpSecretTextView?.addTextChangedListener(object: TextWatcher {
             override fun afterTextChanged(s: Editable?) {
                 s?.toString()?.let { userString ->
-
                     if (userString.length >= MIN_OTP_SECRET) {
                         try {
                             mOtpElement.setBase32Secret(userString.uppercase(Locale.ENGLISH))

--- a/app/src/main/java/com/kunzisoft/keepass/activities/dialogs/SetOTPDialogFragment.kt
+++ b/app/src/main/java/com/kunzisoft/keepass/activities/dialogs/SetOTPDialogFragment.kt
@@ -224,6 +224,9 @@ class SetOTPDialogFragment : DatabaseDialogFragment() {
             }
             otpAlgorithmSpinner?.adapter = otpAlgorithmAdapter
 
+            // Ensure that the UX does not prevent user from hiding/unhiding text
+            otpSecretContainer?.errorIconDrawable = null
+
             // Set the default value of OTP element
             upgradeType()
             upgradeTokenType()
@@ -309,12 +312,16 @@ class SetOTPDialogFragment : DatabaseDialogFragment() {
         // Set secret in OtpElement
         otpSecretTextView?.addTextChangedListener(object: TextWatcher {
             override fun afterTextChanged(s: Editable?) {
-                s?.toString()?.let { userString ->
-                    try {
-                        mOtpElement.setBase32Secret(userString.uppercase(Locale.ENGLISH))
+                s?.toString()?.let { userString ->   
+                    if (userString.length >= 8) {
+                        try {
+                            mOtpElement.setBase32Secret(userString.uppercase(Locale.ENGLISH))
+                            otpSecretContainer?.error = null
+                        } catch (exception: Exception) {
+                            otpSecretContainer?.error = getString(R.string.error_otp_secret_key)
+                        }
+                    } else {
                         otpSecretContainer?.error = null
-                    } catch (exception: Exception) {
-                        otpSecretContainer?.error = getString(R.string.error_otp_secret_key)
                     }
                     mSecretWellFormed = otpSecretContainer?.error == null
                 }

--- a/app/src/main/java/com/kunzisoft/keepass/activities/dialogs/SetOTPDialogFragment.kt
+++ b/app/src/main/java/com/kunzisoft/keepass/activities/dialogs/SetOTPDialogFragment.kt
@@ -41,6 +41,7 @@ import com.kunzisoft.keepass.otp.OtpElement.Companion.MAX_TOTP_PERIOD
 import com.kunzisoft.keepass.otp.OtpElement.Companion.MIN_HOTP_COUNTER
 import com.kunzisoft.keepass.otp.OtpElement.Companion.MIN_OTP_DIGITS
 import com.kunzisoft.keepass.otp.OtpElement.Companion.MIN_TOTP_PERIOD
+import com.kunzisoft.keepass.otp.OtpElement.Companion.MIN_OTP_SECRET
 import com.kunzisoft.keepass.otp.OtpTokenType
 import com.kunzisoft.keepass.otp.OtpType
 import com.kunzisoft.keepass.otp.TokenCalculator
@@ -312,8 +313,9 @@ class SetOTPDialogFragment : DatabaseDialogFragment() {
         // Set secret in OtpElement
         otpSecretTextView?.addTextChangedListener(object: TextWatcher {
             override fun afterTextChanged(s: Editable?) {
-                s?.toString()?.let { userString ->   
-                    if (userString.length >= 8) {
+                s?.toString()?.let { userString ->
+
+                    if (userString.length >= MIN_OTP_SECRET) {
                         try {
                             mOtpElement.setBase32Secret(userString.uppercase(Locale.ENGLISH))
                             otpSecretContainer?.error = null
@@ -321,7 +323,8 @@ class SetOTPDialogFragment : DatabaseDialogFragment() {
                             otpSecretContainer?.error = getString(R.string.error_otp_secret_key)
                         }
                     } else {
-                        otpSecretContainer?.error = null
+                        otpSecretContainer?.error = getString(R.string.error_otp_secret_length,
+                            MIN_OTP_SECRET)
                     }
                     mSecretWellFormed = otpSecretContainer?.error == null
                 }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -187,6 +187,7 @@
     <string name="error_create_database_file">Unable to create database with this password and keyfile.</string>
     <string name="error_save_database">Could not save the database.</string>
     <string name="error_otp_secret_key">Secret key must be in Base32 format.</string>
+    <string name="error_otp_secret_length">Secret key must be at least %1$d characters.</string>
     <string name="error_otp_counter">Counter must be between %1$d and %2$d.</string>
     <string name="error_otp_period">Period must be between %1$d and %2$d seconds.</string>
     <string name="error_otp_digits">Token must contain %1$d to %2$d digits.</string>

--- a/database/src/main/java/com/kunzisoft/keepass/otp/OtpElement.kt
+++ b/database/src/main/java/com/kunzisoft/keepass/otp/OtpElement.kt
@@ -216,6 +216,8 @@ data class OtpElement(var otpModel: OtpModel = OtpModel()) {
         const val MIN_OTP_DIGITS = 4
         const val MAX_OTP_DIGITS = 18
 
+        const val MIN_OTP_SECRET = 8
+
         fun isValidCounter(counter: Long): Boolean {
             return counter in MIN_HOTP_COUNTER..MAX_HOTP_COUNTER
         }


### PR DESCRIPTION
Fixed the OTP setup UI issue where the show/hide key button was being blocked by the bad format error icon. This is achieved by setting errorIconDrawable to null on otpSecretContainer. 

Added length checking for secret length so that Base32 checking does not occur until a minimum length occurs. This is acheived by setting a simple if statement within the otpSecretTextView Listener logic. The else statement to set otpSecretContainer.error to null is necessary, as the error message will stay put if the user starts deleting characters below the limit whilst the error message is active.  I have set the minimum length to 8, but this number can be easily changed. It must also set otpSecretContainer.error to invalid length, because if you don't it will not check for minimum length when the user hits ok, allowing the user to bypass the base32 check.

(This is my very first pull request ever)

Fixes #2048