### PR TITLE
Show Spaces in Passwords

### DIFF
--- a/app/src/main/java/com/kunzisoft/keepass/password/PasswordGenerator.kt
+++ b/app/src/main/java/com/kunzisoft/keepass/password/PasswordGenerator.kt
@@ -21,10 +21,9 @@ package com.kunzisoft.keepass.password
 
 import android.content.res.Resources
 import android.graphics.Color
-import android.text.Editable
 import android.text.Spannable
 import android.text.SpannableString
-import android.text.SpannableStringBuilder
+import android.text.style.CharacterStyle
 import android.text.style.ForegroundColorSpan
 import com.kunzisoft.keepass.R
 import java.security.SecureRandom
@@ -122,7 +121,7 @@ class PasswordGenerator(private val resources: Resources) {
             }
             if (extended) {
                 addFilter(
-                    extendedChars(),
+                    extendedChars,
                     if (atLeastOneFromEach) 1 else 0
                 )
             }
@@ -233,7 +232,7 @@ class PasswordGenerator(private val resources: Resources) {
         private const val AMBIGUOUS_CHARS = "iI|lLoO01"
 
         // From KeePassXC code https://github.com/keepassxreboot/keepassxc/pull/538
-        private fun extendedChars(): String {
+        private val extendedChars = run {
             val charSet = StringBuilder()
             // [U+0080, U+009F] are C1 control characters,
             // U+00A0 is non-breaking space
@@ -251,65 +250,38 @@ class PasswordGenerator(private val resources: Resources) {
                 ++ch
             }
             charSet.append('\u00FF')
-            return charSet.toString()
+            charSet.toString()
         }
 
-        fun colorizedPassword(editable: Editable?) {
-            editable.toString().forEachIndexed { index, char ->
-                colorFromChar(char)?.let { color ->
-                    editable?.setSpan(
-                        ForegroundColorSpan(color),
-                        index,
-                        index + 1,
-                        Spannable.SPAN_EXCLUSIVE_EXCLUSIVE
-                    )
-                }
-            }
-        }
-
-        fun getColorizedPassword(password: String): Spannable {
-            val spannableString = SpannableStringBuilder()
-            if (password.isNotEmpty()) {
-                password.forEach { char ->
-                    colorFromChar(char)?.let { color ->
-                        val spannableColorChar = SpannableString(char.toString())
-                        spannableColorChar.setSpan(
-                            ForegroundColorSpan(color),
-                            0,
-                            1,
-                            Spannable.SPAN_EXCLUSIVE_EXCLUSIVE
-                        )
-                        spannableString.append(spannableColorChar)
-                    } ?: spannableString.append(char)
-                }
-            }
-            return spannableString
-        }
-
-        private fun colorFromChar(char: Char): Int? {
+        private fun getStyleForChar(char: Char): android.text.style.CharacterStyle? {
             return when {
-                DIGIT_CHARS.contains(char) -> {
-                    // RED
-                    Color.rgb(246, 79, 62)
-                }
-                SPECIAL_CHARS.contains(char) -> {
-                    // Blue
-                    Color.rgb(39, 166, 228)
-                }
-                MINUS_CHAR.contains(char)||
-                        UNDERLINE_CHAR.contains(char)||
-                        BRACKET_CHARS.contains(char) -> {
-                    // Purple
-                    Color.rgb(185, 38, 209)
-                }
-                extendedChars().contains(char) -> {
-                    // Green
-                    Color.rgb(44, 181, 50)
-                }
-                else -> {
-                    null
-                }
+                DIGIT_CHARS   .contains(char) -> ForegroundColorSpan(Color.rgb(246,  79,  62)) // RED
+                SPECIAL_CHARS .contains(char) -> ForegroundColorSpan(Color.rgb( 39, 166, 228)) // BLUE
+                BRACKET_CHARS .contains(char) -> ForegroundColorSpan(Color.rgb(185,  38, 209)) // PURPLE
+                MINUS_CHAR    .contains(char) -> ForegroundColorSpan(Color.rgb(185,  38, 209)) // PURPLE
+                UNDERLINE_CHAR.contains(char) -> ForegroundColorSpan(Color.rgb(185,  38, 209)) // PURPLE
+                extendedChars .contains(char) -> ForegroundColorSpan(Color.rgb( 44, 181,  50)) // GREEN
+                else -> null
             }
         }
+
+        // filter that is called whenever the password text changes to style the new characters
+        val passwordStylingInputFilter = object: android.text.InputFilter {
+            override fun filter(source: CharSequence, start: Int, end: Int, dest: android.text.Spanned, dstart: Int, dend: Int): CharSequence? {
+                // clear existing spans, only use given range
+                val src = source.toString().substring(start, end)
+                val spannable = SpannableString(src)
+
+                // apply styling per character
+                spannable.forEachIndexed { i, char ->
+                    getStyleForChar(char)?.let { charStyle ->
+                        spannable.setSpan(charStyle, i, i+1, Spannable.SPAN_EXCLUSIVE_EXCLUSIVE)
+                    }
+                }
+
+                return spannable
+            }
+        }
+
     }
 }

--- a/app/src/main/java/com/kunzisoft/keepass/password/PasswordGenerator.kt
+++ b/app/src/main/java/com/kunzisoft/keepass/password/PasswordGenerator.kt
@@ -20,11 +20,14 @@
 package com.kunzisoft.keepass.password
 
 import android.content.res.Resources
+import android.graphics.Canvas
 import android.graphics.Color
+import android.graphics.Paint
 import android.text.Spannable
 import android.text.SpannableString
 import android.text.style.CharacterStyle
 import android.text.style.ForegroundColorSpan
+import android.text.style.ReplacementSpan
 import com.kunzisoft.keepass.R
 import java.security.SecureRandom
 import java.util.*
@@ -253,8 +256,20 @@ class PasswordGenerator(private val resources: Resources) {
             charSet.toString()
         }
 
+        // span to make a character look like a different one
+        private class CharacterSkinSpan(val color: Int, val replacement: String) : ReplacementSpan() {
+            override fun getSize(paint: Paint, text: CharSequence?, start: Int, end: Int, fm: Paint.FontMetricsInt?): Int {
+                return paint.measureText(replacement).toInt()
+            }
+            override fun draw(canvas: Canvas, text: CharSequence?, start: Int, end: Int, x: Float, top: Int, y: Int, bottom: Int, paint: Paint) {
+                paint.color = color
+                canvas.drawText(replacement, x, y.toFloat(), paint)
+            }
+        }
+
         private fun getStyleForChar(char: Char): android.text.style.CharacterStyle? {
             return when {
+                char == ' '                   -> CharacterSkinSpan(Color.rgb(80, 80, 80), "•") // GRAY "•"
                 DIGIT_CHARS   .contains(char) -> ForegroundColorSpan(Color.rgb(246,  79,  62)) // RED
                 SPECIAL_CHARS .contains(char) -> ForegroundColorSpan(Color.rgb( 39, 166, 228)) // BLUE
                 BRACKET_CHARS .contains(char) -> ForegroundColorSpan(Color.rgb(185,  38, 209)) // PURPLE

--- a/app/src/main/java/com/kunzisoft/keepass/view/PasswordEditView.kt
+++ b/app/src/main/java/com/kunzisoft/keepass/view/PasswordEditView.kt
@@ -22,8 +22,6 @@ package com.kunzisoft.keepass.view
 import android.content.Context
 import android.text.Editable
 import android.text.InputType
-import android.text.Spannable
-import android.text.SpannableString
 import android.text.TextWatcher
 import android.util.AttributeSet
 import android.view.LayoutInflater
@@ -146,18 +144,11 @@ class PasswordEditView @JvmOverloads constructor(context: Context,
         mPasswordTextWatchers.remove(textWatcher)
     }
 
-    private fun spannableValue(value: String): Spannable {
-        return if (PreferencesUtil.colorizePassword(context))
-            PasswordGenerator.getColorizedPassword(value)
-        else
-            SpannableString(value)
-    }
-
     var passwordString: String
         get() {
             return passwordText.text.toString()
         }
         set(value) {
-            passwordText.setText(spannableValue(value))
+            passwordText.setText(value)
         }
 }

--- a/app/src/main/java/com/kunzisoft/keepass/view/PasswordEditView.kt
+++ b/app/src/main/java/com/kunzisoft/keepass/view/PasswordEditView.kt
@@ -76,6 +76,7 @@ class PasswordEditView @JvmOverloads constructor(context: Context,
         passwordInputLayout = findViewById(R.id.password_edit_input_layout)
         passwordInputLayout?.hint = mViewHint
         passwordText = findViewById(R.id.password_edit_text)
+        passwordText.filters += PasswordGenerator.passwordStylingInputFilter
         if (mShowPassword) {
             passwordText?.inputType = passwordText.inputType or
                     InputType.TYPE_TEXT_VARIATION_VISIBLE_PASSWORD
@@ -114,7 +115,6 @@ class PasswordEditView @JvmOverloads constructor(context: Context,
                     it.afterTextChanged(editable)
                 }
                 getEntropyStrength(editable.toString())
-                PasswordGenerator.colorizedPassword(editable)
             }
         }
         passwordText?.addTextChangedListener(mPasswordTextWatcher)

--- a/app/src/main/java/com/kunzisoft/keepass/view/PasswordTextEditFieldView.kt
+++ b/app/src/main/java/com/kunzisoft/keepass/view/PasswordTextEditFieldView.kt
@@ -89,8 +89,8 @@ class PasswordTextEditFieldView @JvmOverloads constructor(context: Context,
 
         valueView.doAfterTextChanged { editable ->
             getEntropyStrength(editable.toString())
-            PasswordGenerator.colorizedPassword(editable)
         }
+        valueView.filters += PasswordGenerator.passwordStylingInputFilter
 
         addView(mPasswordProgress)
         addView(mPasswordEntropyView)

--- a/app/src/main/java/com/kunzisoft/keepass/view/PasswordTextEditFieldView.kt
+++ b/app/src/main/java/com/kunzisoft/keepass/view/PasswordTextEditFieldView.kt
@@ -21,7 +21,6 @@ package com.kunzisoft.keepass.view
 
 import android.content.Context
 import android.os.Build
-import android.text.Spannable
 import android.util.AttributeSet
 import android.util.TypedValue
 import android.widget.TextView
@@ -33,7 +32,6 @@ import com.google.android.material.progressindicator.LinearProgressIndicator
 import com.kunzisoft.keepass.R
 import com.kunzisoft.keepass.password.PasswordEntropy
 import com.kunzisoft.keepass.password.PasswordGenerator
-import com.kunzisoft.keepass.settings.PreferencesUtil
 
 
 class PasswordTextEditFieldView @JvmOverloads constructor(context: Context,
@@ -46,7 +44,6 @@ class PasswordTextEditFieldView @JvmOverloads constructor(context: Context,
             getEntropyStrength(firstPassword)
         }
     }
-    private var isColorizedPasswordActivated = PreferencesUtil.colorizePassword(context)
 
     private var passwordProgressViewId = ViewCompat.generateViewId()
     private var passwordEntropyViewId = ViewCompat.generateViewId()
@@ -134,15 +131,6 @@ class PasswordTextEditFieldView @JvmOverloads constructor(context: Context,
                 }
             }
         }
-    }
-
-    override fun spannableValue(value: String?): Spannable? {
-        if (value == null)
-            return null
-        return if (isColorizedPasswordActivated)
-            PasswordGenerator.getColorizedPassword(value)
-        else
-            super.spannableValue(value)
     }
 
     override var label: String

--- a/app/src/main/java/com/kunzisoft/keepass/view/PasswordTextFieldView.kt
+++ b/app/src/main/java/com/kunzisoft/keepass/view/PasswordTextFieldView.kt
@@ -76,6 +76,12 @@ class PasswordTextFieldView @JvmOverloads constructor(context: Context,
             }
         }
 
+    init {
+        if (PreferencesUtil.colorizePassword(context)) {
+            valueView.filters += PasswordGenerator.passwordStylingInputFilter
+        }
+    }
+
     override fun setLabel(@StringRes labelId: Int) {
         label = resources.getString(labelId)
     }
@@ -85,12 +91,7 @@ class PasswordTextFieldView @JvmOverloads constructor(context: Context,
             return valueView.text.toString()
         }
         set(value) {
-            val spannableString =
-                if (PreferencesUtil.colorizePassword(context))
-                    PasswordGenerator.getColorizedPassword(value)
-                else
-                    SpannableString(value)
-            valueView.text = spannableString
+            valueView.text = value
             changeProtectedValueParameters()
         }
 

--- a/app/src/main/java/com/kunzisoft/keepass/view/TextEditFieldView.kt
+++ b/app/src/main/java/com/kunzisoft/keepass/view/TextEditFieldView.kt
@@ -4,8 +4,6 @@ import android.content.Context
 import android.os.Build
 import android.text.InputFilter
 import android.text.InputType
-import android.text.Spannable
-import android.text.SpannableString
 import android.util.AttributeSet
 import android.util.TypedValue
 import android.view.View
@@ -126,16 +124,12 @@ open class TextEditFieldView @JvmOverloads constructor(context: Context,
             buildViews()
         }
 
-    protected open fun spannableValue(value: String?): Spannable? {
-        return SpannableString(value)
-    }
-
     override var value: String
         get() {
             return valueView.text?.toString() ?: ""
         }
         set(value) {
-            valueView.setText(spannableValue(value))
+            valueView.setText(value)
         }
 
     override var default: String = ""


### PR DESCRIPTION
See #1691

Yeah, so I thought this would be easier - it's not done yet.

I used `android.text.style.ReplacementSpan` to render a gray "•" in place of spaces. This works really well everywhere except around line wraps - which were the whole reason I wanted this in the first place. This is the current state of the code (see first image). The main, almost trivial change for the feature itself is in fc43527f85ebfd69b37c2b1db59b54f91982a40e. In the 2 commits before that I reworked the coloring code a bit - I believe for the better.

It's easy to get the looks right by swapping the underlying space character to something else and rendering that as gray dot (see right image). This is problematic because copying the text then has that other character and no spaces in it. You can easily fix this for the copy button, but I'm not sure about manual text selection and the cut/copy popups.

I'm going to keep working on this to try and find something that works. Until then, maybe someone else has a good idea or has some use for what I've done so far.

<img width="45%" src="https://github.com/user-attachments/assets/fc02d341-3fb3-4377-88ee-184a73d56603" />
<img width="45%" src="https://github.com/user-attachments/assets/93be7699-dd68-4d45-b6a2-23a523b6fc32" />

