### PR TITLE
Prefer biometric unlock

### DIFF
--- a/app/src/main/java/com/kunzisoft/keepass/biometric/AdvancedUnlockFragment.kt
+++ b/app/src/main/java/com/kunzisoft/keepass/biometric/AdvancedUnlockFragment.kt
@@ -60,6 +60,7 @@ class AdvancedUnlockFragment: Fragment(), AdvancedUnlockManager.AdvancedUnlockCa
 
     private var mAdvancedUnlockEnabled = false
     private var mAutoOpenPromptEnabled = false
+    private var mPreferAdvancedUnlockPrompt = false
 
     private var advancedUnlockManager: AdvancedUnlockManager? = null
     private var biometricMode: Mode = Mode.BIOMETRIC_UNAVAILABLE
@@ -174,6 +175,7 @@ class AdvancedUnlockFragment: Fragment(), AdvancedUnlockManager.AdvancedUnlockCa
         context?.let {
             mAdvancedUnlockEnabled = PreferencesUtil.isAdvancedUnlockEnable(it)
             mAutoOpenPromptEnabled = PreferencesUtil.isAdvancedUnlockPromptAutoOpenEnable(it)
+            mPreferAdvancedUnlockPrompt = PreferencesUtil.isPreferAdvancedUnlockPromptEnable(it)
         }
         keepConnection = false
     }
@@ -407,7 +409,9 @@ class AdvancedUnlockFragment: Fragment(), AdvancedUnlockManager.AdvancedUnlockCa
                             // Auto open the biometric prompt
                             if (mAdvancedUnlockViewModel.allowAutoOpenBiometricPrompt
                                 && mAutoOpenPromptEnabled) {
-                                mAdvancedUnlockViewModel.allowAutoOpenBiometricPrompt = false
+                                if (! mPreferAdvancedUnlockPrompt) {
+                                    mAdvancedUnlockViewModel.allowAutoOpenBiometricPrompt = false
+                                }
                                 openAdvancedUnlockPrompt(cryptoPrompt)
                             }
                         }
@@ -541,6 +545,9 @@ class AdvancedUnlockFragment: Fragment(), AdvancedUnlockManager.AdvancedUnlockCa
                             cipherDatabase?.encryptedValue?.let { value ->
                                 advancedUnlockManager?.decryptData(value)
                             } ?: deleteEncryptedDatabaseKey()
+                            if (mAutoOpenPromptEnabled && mPreferAdvancedUnlockPrompt) {
+                                mAdvancedUnlockViewModel.allowAutoOpenBiometricPrompt = true
+                            }
                         }
                     } ?: run {
                         onAuthenticationError(-1, getString(R.string.error_database_uri_null))

--- a/app/src/main/java/com/kunzisoft/keepass/settings/PreferencesUtil.kt
+++ b/app/src/main/java/com/kunzisoft/keepass/settings/PreferencesUtil.kt
@@ -538,6 +538,12 @@ object PreferencesUtil {
             context.resources.getBoolean(R.bool.biometric_auto_open_prompt_default))
     }
 
+    fun isPreferAdvancedUnlockPromptEnable(context: Context): Boolean {
+        val prefs = PreferenceManager.getDefaultSharedPreferences(context)
+        return prefs.getBoolean(context.getString(R.string.prefer_biometric_prompt_key),
+            context.resources.getBoolean(R.bool.prefer_biometric_prompt_default))
+    }
+
     fun getListSort(context: Context): SortNodeEnum {
         try {
             val prefs = PreferenceManager.getDefaultSharedPreferences(context)

--- a/app/src/main/res/values/donottranslate.xml
+++ b/app/src/main/res/values/donottranslate.xml
@@ -105,6 +105,8 @@
     <bool name="device_credential_unlock_enable_default" translatable="false">false</bool>
     <string name="biometric_auto_open_prompt_key" translatable="false">biometric_auto_open_prompt_key</string>
     <bool name="biometric_auto_open_prompt_default" translatable="false">true</bool>
+    <string name="prefer_biometric_prompt_key" translatable="false">prefer_biometric_prompt_key</string>
+    <bool name="prefer_biometric_prompt_default" translatable="false">false</bool>
     <string name="temp_advanced_unlock_enable_key" translatable="false">temp_advanced_unlock_enable_key</string>
     <bool name="temp_advanced_unlock_enable_default" translatable="false">false</bool>
     <string name="temp_advanced_unlock_timeout_key" translatable="false">temp_advanced_unlock_timeout_key</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -453,6 +453,8 @@
     <string name="device_credential_unlock_enable_summary">Lets you use your device credential to open the database</string>
     <string name="biometric_auto_open_prompt_title">Auto-open prompt</string>
     <string name="biometric_auto_open_prompt_summary">Automatically request device unlock if the database is set up to use it</string>
+    <string name="prefer_biometric_prompt_title">Prefer biometric prompt</string>
+    <string name="prefer_biometric_prompt_summary">Show the biometric prompt if auto-open is enabled and biometrics were previously used for unlock</string>
     <string name="temp_advanced_unlock_enable_title">Temp device unlocking</string>
     <string name="temp_advanced_unlock_enable_summary">Do not store any encrypted content to use device unlocking</string>
     <string name="temp_advanced_unlock_timeout_title">Device unlocking expiration</string>

--- a/app/src/main/res/xml/preferences_advanced_unlock.xml
+++ b/app/src/main/res/xml/preferences_advanced_unlock.xml
@@ -39,6 +39,11 @@
             android:title="@string/biometric_auto_open_prompt_title"
             android:summary="@string/biometric_auto_open_prompt_summary"
             android:defaultValue="@bool/biometric_auto_open_prompt_default"/>
+        <SwitchPreferenceCompat
+            android:key="@string/prefer_biometric_prompt_key"
+            android:title="@string/prefer_biometric_prompt_title"
+            android:summary="@string/prefer_biometric_prompt_summary"
+            android:defaultValue="@bool/prefer_biometric_prompt_default"/>
     </PreferenceCategory>
     <PreferenceCategory
         android:title="@string/content">


### PR DESCRIPTION
This implements the feature request from #2105 

It adds a new preference option to prefer biometric unlock if auto-prompt is enabled AND  biometric prompt was used to unlock the device previously.  This results in getting the biometric prompt when unlocking the db after unlocking the phone, but not if the db was manually locked via the lock icon.

Honestly, I'm not really sure it is necessary to hide this behind a setting, as the feature feels intuitive to me, but I added the setting to preserve the existing behavior.