### PR TITLE
Simplify inset logic, fix landscape mode, fix cutout overlapping

### DIFF
--- a/app/src/main/java/com/kunzisoft/keepass/activities/EntryActivity.kt
+++ b/app/src/main/java/com/kunzisoft/keepass/activities/EntryActivity.kt
@@ -23,7 +23,6 @@ import android.content.Intent
 import android.graphics.Color
 import android.graphics.drawable.ColorDrawable
 import android.net.Uri
-import android.os.Build
 import android.os.Bundle
 import android.os.Handler
 import android.os.Looper
@@ -38,13 +37,10 @@ import androidx.activity.result.ActivityResultLauncher
 import androidx.activity.viewModels
 import androidx.appcompat.widget.Toolbar
 import androidx.coordinatorlayout.widget.CoordinatorLayout
-import androidx.core.content.ContextCompat
-import androidx.core.content.res.ResourcesCompat
 import androidx.core.graphics.BlendModeColorFilterCompat
 import androidx.core.graphics.BlendModeCompat
 import androidx.core.graphics.ColorUtils
 import androidx.core.view.ViewCompat
-import androidx.core.view.WindowCompat
 import androidx.recyclerview.widget.LinearLayoutManager
 import androidx.recyclerview.widget.RecyclerView
 import com.google.android.material.appbar.AppBarLayout
@@ -83,11 +79,13 @@ import com.kunzisoft.keepass.view.hideByFading
 import com.kunzisoft.keepass.view.setTransparentNavigationBar
 import com.kunzisoft.keepass.view.showActionErrorIfNeeded
 import com.kunzisoft.keepass.viewmodels.EntryViewModel
+import java.util.EnumSet
 import java.util.UUID
 
 class EntryActivity : DatabaseLockActivity() {
 
     private var footer: ViewGroup? = null
+    private var container: View? = null
     private var coordinatorLayout: CoordinatorLayout? = null
     private var collapsingToolbarLayout: CollapsingToolbarLayout? = null
     private var appBarLayout: AppBarLayout? = null
@@ -139,6 +137,7 @@ class EntryActivity : DatabaseLockActivity() {
 
         // Get views
         footer = findViewById(R.id.activity_entry_footer)
+        container = findViewById(R.id.activity_entry_container)
         coordinatorLayout = findViewById(R.id.toolbar_coordinator)
         collapsingToolbarLayout = findViewById(R.id.toolbar_layout)
         appBarLayout = findViewById(R.id.app_bar)
@@ -154,8 +153,12 @@ class EntryActivity : DatabaseLockActivity() {
         setTransparentNavigationBar {
             // To fix margin with API 27
             ViewCompat.setOnApplyWindowInsetsListener(collapsingToolbarLayout!!, null)
-            coordinatorLayout?.applyWindowInsets(WindowInsetPosition.TOP)
-            footer?.applyWindowInsets(WindowInsetPosition.BOTTOM)
+            container?.applyWindowInsets(EnumSet.of(
+                WindowInsetPosition.TOP_MARGINS,
+                WindowInsetPosition.BOTTOM_MARGINS,
+                WindowInsetPosition.START_MARGINS,
+                WindowInsetPosition.END_MARGINS,
+            ))
         }
 
         // Empty title

--- a/app/src/main/java/com/kunzisoft/keepass/activities/EntryEditActivity.kt
+++ b/app/src/main/java/com/kunzisoft/keepass/activities/EntryEditActivity.kt
@@ -100,6 +100,7 @@ import com.kunzisoft.keepass.view.showActionErrorIfNeeded
 import com.kunzisoft.keepass.view.updateLockPaddingStart
 import com.kunzisoft.keepass.viewmodels.ColorPickerViewModel
 import com.kunzisoft.keepass.viewmodels.EntryEditViewModel
+import java.util.EnumSet
 import java.util.UUID
 
 class EntryEditActivity : DatabaseLockActivity(),
@@ -180,8 +181,12 @@ class EntryEditActivity : DatabaseLockActivity(),
 
         // To apply fit window with transparency
         setTransparentNavigationBar(applyToStatusBar = true) {
-            container?.applyWindowInsets(WindowInsetPosition.TOP_BOTTOM_IME)
-            footer?.applyWindowInsets(WindowInsetPosition.BOTTOM_IME)
+            container?.applyWindowInsets(EnumSet.of(
+                WindowInsetPosition.TOP_MARGINS,
+                WindowInsetPosition.BOTTOM_MARGINS,
+                WindowInsetPosition.START_MARGINS,
+                WindowInsetPosition.END_MARGINS,
+            ))
         }
 
         stopService(Intent(this, ClipboardEntryNotificationService::class.java))

--- a/app/src/main/java/com/kunzisoft/keepass/activities/GroupActivity.kt
+++ b/app/src/main/java/com/kunzisoft/keepass/activities/GroupActivity.kt
@@ -48,6 +48,7 @@ import androidx.appcompat.app.AppCompatActivity
 import androidx.appcompat.view.ActionMode
 import androidx.appcompat.widget.SearchView
 import androidx.appcompat.widget.Toolbar
+import androidx.constraintlayout.widget.ConstraintLayout
 import androidx.coordinatorlayout.widget.CoordinatorLayout
 import androidx.core.view.GravityCompat
 import androidx.core.view.WindowInsetsCompat
@@ -117,6 +118,7 @@ import com.kunzisoft.keepass.view.updateLockPaddingStart
 import com.kunzisoft.keepass.viewmodels.GroupEditViewModel
 import com.kunzisoft.keepass.viewmodels.GroupViewModel
 import org.joda.time.LocalDateTime
+import java.util.EnumSet
 
 
 class GroupActivity : DatabaseLockActivity(),
@@ -131,6 +133,7 @@ class GroupActivity : DatabaseLockActivity(),
     private var header: ViewGroup? = null
     private var footer: ViewGroup? = null
     private var drawerLayout: DrawerLayout? = null
+    private var constraintLayout: ConstraintLayout? = null
     private var databaseNavView: NavigationDatabaseView? = null
     private var coordinatorLayout: CoordinatorLayout? = null
     private var coordinatorError: CoordinatorLayout? = null
@@ -279,6 +282,7 @@ class GroupActivity : DatabaseLockActivity(),
         header = findViewById(R.id.activity_group_header)
         footer = findViewById(R.id.activity_group_footer)
         drawerLayout = findViewById(R.id.drawer_layout)
+        constraintLayout = findViewById(R.id.activity_group_container_view)
         databaseNavView = findViewById(R.id.database_nav_view)
         coordinatorLayout = findViewById(R.id.group_coordinator)
         coordinatorError = findViewById(R.id.error_coordinator)
@@ -296,8 +300,19 @@ class GroupActivity : DatabaseLockActivity(),
 
         // To apply fit window with transparency
         setTransparentNavigationBar(applyToStatusBar = true) {
-            drawerLayout?.applyWindowInsets(WindowInsetPosition.TOP_BOTTOM_IME)
-            footer?.applyWindowInsets(WindowInsetPosition.BOTTOM_IME)
+            constraintLayout?.applyWindowInsets(EnumSet.of(
+                WindowInsetPosition.TOP_MARGINS,
+                WindowInsetPosition.BOTTOM_MARGINS,
+                WindowInsetPosition.START_MARGINS,
+                WindowInsetPosition.END_MARGINS,
+            ))
+            // The background of the drawer is meant to overlap system bars, so use padding
+            databaseNavView?.applyWindowInsets(EnumSet.of(
+                WindowInsetPosition.TOP_PADDING,
+                WindowInsetPosition.BOTTOM_PADDING,
+                // Only on the start side, since the drawer is anchored to one side of the screen
+                WindowInsetPosition.START_PADDING,
+            ))
         }
 
         lockView?.setOnClickListener {

--- a/app/src/main/java/com/kunzisoft/keepass/settings/SettingsActivity.kt
+++ b/app/src/main/java/com/kunzisoft/keepass/settings/SettingsActivity.kt
@@ -70,8 +70,12 @@ open class SettingsActivity
         // To apply navigation bar with background color
         /* TODO Settings nav bar
         setTransparentNavigationBar {
-            coordinatorLayout?.applyWindowInsets(WindowInsetPosition.TOP)
-            footer?.applyWindowInsets(WindowInsetPosition.BOTTOM)
+            coordinatorLayout?.applyWindowInsets(EnumSet.of(
+                WindowInsetPosition.TOP_MARGINS,
+                WindowInsetPosition.BOTTOM_MARGINS,
+                WindowInsetPosition.START_MARGINS,
+                WindowInsetPosition.END_MARGINS,
+            ))
         }*/
 
         mExternalFileHelper = ExternalFileHelper(this)

--- a/app/src/main/res/layout/activity_entry.xml
+++ b/app/src/main/res/layout/activity_entry.xml
@@ -20,6 +20,7 @@
 <androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
+    android:id="@+id/activity_entry_container"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
     android:filterTouchesWhenObscured="true">


### PR DESCRIPTION
I've tested this on:

* API 36 (Android 16 QPR1) - Pixel Tablet
* API 36 (Android 16) - Pixel 10 Pro XL
* API 33 - Emulator
* API 29 - Emulator
* API 27 - Emulator
* API 26 - Emulator
* API 23 - Emulator
* API 21 - Emulator
* API 19 - Emulator

I unfortunately don't have any way to test on more finicky devices, like Xiaomi. I don't think this PR would break anything there, but if anyone is able to test, it would be much appreciated!

---

The commit primarily fixes a few overlapping issues caused by the window inset handling. Previously, there were two main issues:

* Because `setTransparentNavigationBar()` checked for portrait mode, the inset logic never executed in landscape mode. This caused the app to overlap the status bar and navigation bar.

* The inset logic did not have handling for `displayCutout` insets. In landscape mode, this would cause the app to overlap the notch or camera hole punch area on phones.

In addition to fixing those issues, this commit simplifies the inset logic a bit:

* `applyWindowInsets()` now accepts an `EnumSet` of `WindowInsetPosition` to avoid needing to duplicate logic for the various position combinations.

* Insets are now applied to the main container in the layout instead of individual elements where possible. This eliminates the need for the previous manual IME height handling logic in `BOTTOM_IME` vs `TOP_BOTTOM_IME` (for avoiding the insets being applied twice).

* Since insets are now applied to the main layout container, `applyWindowInsets()` now takes `systemBars`, `displayCutout`, and `ime` all into consideration. This should avoid all possible overlapping.

* Add support for using padding instead of margins for insets. This is used for `GroupActivity`'s navigation drawer, where Material design intends for the drawer background to be drawn behind system bars.

---

Screenshots of issues being fixed:

* [`GroupActivity`] In landscape mode, the status bar, navigation bar, and camera hole are all overlapped.
  * Before: [screenshot](https://github.com/user-attachments/assets/4d60f686-39ec-4541-b083-7cf1c2a4ed38)
  * After: [screenshot](https://github.com/user-attachments/assets/2e7d60cc-9706-498c-82d1-36bc61cafb33)

* [`GroupActivity`] In landscape mode, the navigation drawer overlaps the camera hole and has a shadow drawn on top.
  * Before: [screenshot](https://github.com/user-attachments/assets/5a85b727-436b-44ba-a6c7-ddd89dc98ed1)
  * After: [screenshot](https://github.com/user-attachments/assets/a4fe893a-6356-4753-8afa-d255d1dcf2bb)

* [`EntryEditActivity`] In landscape mode on phones, the status bar, navigation bar, and camera hole are all overlapped. However, when the IME is visible, this is more apparent as the contents of the app "leak" through.
  * Before: [screenshot](https://github.com/user-attachments/assets/21049fb4-217f-47cc-9408-a473e932f5f7)
  * After: [screenshot](https://github.com/user-attachments/assets/469dc26e-0f2b-4188-b44a-9c982f5ca4f2)

* [`EntryEditActivity`] In landscape mode on tablets, everything is once again overlapped. However, since the IME is not fullscreen, this makes it impossible to access the bottom half of the app (fields, footer, etc.).
  * Before: [screenshot](https://github.com/user-attachments/assets/2d42cab7-923e-4628-b8ab-2e75ce79029f)
  * After: [screenshot](https://github.com/user-attachments/assets/80c253bb-4fbb-4a58-a339-470eefaea34c)

---

Fixes: #2198