### PR TITLE
Add support for IronFox Nightly

### DIFF
--- a/app/src/free/assets/passkeys_privileged_apps_community.json
+++ b/app/src/free/assets/passkeys_privileged_apps_community.json
@@ -51,6 +51,18 @@
     {
       "type": "android",
       "info": {
+        "package_name": "org.ironfoxoss.ironfox.nightly",
+        "signatures": [
+          {
+            "build": "release",
+            "cert_fingerprint_sha256": "C5:E2:91:B5:A5:71:F9:C8:CD:9A:97:99:C2:C9:4E:02:EC:97:03:94:88:93:F2:CA:75:6D:67:B9:42:04:F9:04"
+          }
+        ]
+      }
+    },
+    {
+      "type": "android",
+      "info": {
         "package_name": "org.mozilla.fennec_fdroid",
         "signatures": [
           {

--- a/app/src/main/res/xml/dataset_service.xml
+++ b/app/src/main/res/xml/dataset_service.xml
@@ -264,6 +264,9 @@ Settings Activity. This is pointed to in the service's meta-data in the applicat
         android:name="org.ironfoxoss.ironfox"
         android:maxLongVersionCode="10000000000" />
     <compatibility-package
+        android:name="org.ironfoxoss.ironfox.nightly"
+        android:maxLongVersionCode="10000000000" />
+    <compatibility-package
         android:name="org.mozilla.fenix"
         android:maxLongVersionCode="10000000000" />
     <compatibility-package


### PR DESCRIPTION
As of https://github.com/ironfox-oss/IronFox/commit/a2c7570bdc4dc824ec3b66f4ec12f9678cbe7de9, we're now using a separate package ID for Nightly builds. This adds support for IronFox Nightly.