### PR TITLE
Enable resolution of S: custom field reference placeholders

### DIFF
--- a/database/src/main/java/com/kunzisoft/keepass/database/element/database/DatabaseKDBX.kt
+++ b/database/src/main/java/com/kunzisoft/keepass/database/element/database/DatabaseKDBX.kt
@@ -608,8 +608,8 @@ class DatabaseKDBX : DatabaseVersioned<UUID, UUID, GroupKDBX, EntryKDBX> {
     /**
      * Retrieve the value of a field reference
      */
-    fun getFieldReferenceValue(textReference: String, recursionLevel: Int): String {
-        return mFieldReferenceEngine.compile(textReference, recursionLevel)
+    fun getFieldReferenceValue(entry: EntryKDBX, textReference: String, recursionLevel: Int): String {
+        return mFieldReferenceEngine.compile(entry, textReference, recursionLevel)
     }
 
     @Throws(IOException::class)

--- a/database/src/main/java/com/kunzisoft/keepass/database/element/entry/EntryKDBX.kt
+++ b/database/src/main/java/com/kunzisoft/keepass/database/element/entry/EntryKDBX.kt
@@ -169,7 +169,7 @@ class EntryKDBX : EntryVersioned<UUID, UUID, GroupKDBX, EntryKDBX>, NodeKDBXInte
     private fun decodeRefKey(decodeRef: Boolean, key: String, recursionLevel: Int): String {
         return fields[key]?.toString()?.let { text ->
             return if (decodeRef) {
-                mDatabase?.getFieldReferenceValue(text, recursionLevel) ?: text
+                mDatabase?.getFieldReferenceValue(this, text, recursionLevel) ?: text
             } else text
         } ?: ""
     }
@@ -229,8 +229,8 @@ class EntryKDBX : EntryVersioned<UUID, UUID, GroupKDBX, EntryKDBX>, NodeKDBXInte
             fields[STR_NOTES] = ProtectedString(protect, value)
         }
 
-    fun getCustomFieldValue(label: String): String {
-        return decodeRefKey(mDecodeRef, label, 0)
+    fun getCustomFieldValue(label: String, recursionLevel: Int = 0): String {
+        return decodeRefKey(mDecodeRef, label, recursionLevel)
     }
 
     fun getSize(attachmentPool: AttachmentPool): Long {


### PR DESCRIPTION
**Disclaimer**: I'm neither an android developer nor is Kotlin my main language. Any feedback is appreciated :)

This is a simple attempt at enhancing existing functionality in the `FieldReferencesEngine` class to resolve `S:` as well as `REF:` placeholders.

### Introduced changes:
- Add new parameter for recursion level handling in `EntryKDBX.getCustomFieldValue`. In order to maintain compatibility with existing code, it gets a default value of 0.
- Propagate the entry being currently rendered in `EntryKDBX.decodeRefKey` all the way down to `FieldReferencesEngine.compile`
- Some code branches to differentiate between `REF:` and `S:` placeholders
- Refactoring of cache keys in `FieldReferencesEngine` to accomodate caching of `S:` references as well

### Rationale
I've tried to keep this solution as simple as possible, injecting it close to a working functionality, so I built upon the existing `FieldReferencesEngine` logic to account for `S:` placeholders alongside `REF:` placeholders. This includes its caching mechanism.
However since `S:` placeholders reference custom fields within the same entry, there can be clashes when multiple entries have custom fields with clashing names. To account for this, I introduced disambiguating logic (basically, using `@I:<id>` as a suffix in the cache key) for these cases, which meant leaking _some_ of this responsibility to the `fillReferencesUsingCache` method. I'm happy to rework this if you disagree with my approach.

### Missing work
- Proper android tests - I'm not an android developer myself, so android test coverage is beyond my current skillset. I'm willing to add these for completeness, but I'll need some guidance on how to do it.
- Proper unit tests - The FieldReferencesEngine is not currently covered by any tests, so I didn't add any for the new functionality. I'll gladly do it if you deem it necessary.