### PR TITLE
Add WebLibre to passkeys_privileged_apps_community.json

### DIFF
--- a/app/src/free/assets/passkeys_privileged_apps_community.json
+++ b/app/src/free/assets/passkeys_privileged_apps_community.json
@@ -71,6 +71,38 @@
           }
         ]
       }
+    },
+    {
+      "type": "android",
+      "info": {
+        "package_name": "eu.weblibre.gecko",
+        "signatures": [
+          {
+            "build": "release",
+            "cert_fingerprint_sha256": "BB:2A:97:F5:61:53:35:C9:E5:7C:86:6F:1C:30:ED:4F:D7:D7:BD:DC:BC:BC:06:68:FE:93:A5:79:17:3D:3D:2D"
+          },
+          {
+            "build": "release",
+            "cert_fingerprint_sha256": "8F:52:6E:1E:53:D6:BD:4D:FB:F4:F4:B9:3C:2A:91:EC:B5:CB:8D:A5:E1:4A:D9:4C:25:70:E1:E3:C7:13:52:7F"
+          },
+        ]
+      }
+    },
+    {
+      "type": "android",
+      "info": {
+        "package_name": "eu.weblibre.gecko.alpha",
+        "signatures": [
+          {
+            "build": "release",
+            "cert_fingerprint_sha256": "BB:2A:97:F5:61:53:35:C9:E5:7C:86:6F:1C:30:ED:4F:D7:D7:BD:DC:BC:BC:06:68:FE:93:A5:79:17:3D:3D:2D"
+          },
+          {
+            "build": "release",
+            "cert_fingerprint_sha256": "8F:52:6E:1E:53:D6:BD:4D:FB:F4:F4:B9:3C:2A:91:EC:B5:CB:8D:A5:E1:4A:D9:4C:25:70:E1:E3:C7:13:52:7F"
+          },
+        ]
+      }
     }
   ]
 }


### PR DESCRIPTION
This adds the WebLibre browser (https://github.com/FaFre/WebLibre) to the list of privileged apps.

See https://github.com/bitwarden/android/pull/6299 for a past reference. 