### PR TITLE
Add KeeShare read-only import support

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -173,5 +173,6 @@ dependencies {
     implementation project(path: ':icon-pack')
 
     // Tests
-    androidTestImplementation "androidx.test:runner:$android_test_version"
+    testImplementation "junit:junit:4.13.2"
+    testImplementation "org.robolectric:robolectric:4.11.1"
 }

--- a/app/src/main/java/com/kunzisoft/keepass/activities/GroupActivity.kt
+++ b/app/src/main/java/com/kunzisoft/keepass/activities/GroupActivity.kt
@@ -60,6 +60,10 @@ import com.kunzisoft.keepass.activities.dialogs.SortDialogFragment
 import com.kunzisoft.keepass.activities.fragments.GroupFragment
 import com.kunzisoft.keepass.activities.fragments.SearchFragment
 import com.kunzisoft.keepass.activities.helpers.ExternalFileHelper
+import com.kunzisoft.keepass.database.MainCredential
+import com.kunzisoft.keepass.database.keeshare.KeeShareReference
+import com.kunzisoft.keepass.keeshare.KeeShareObserver
+import com.kunzisoft.keepass.utils.UriUtil.takeUriPermission
 import com.kunzisoft.keepass.activities.legacy.DatabaseLockActivity
 import com.kunzisoft.keepass.adapters.BreadcrumbAdapter
 import com.kunzisoft.keepass.credentialprovider.EntrySelectionHelper
@@ -87,6 +91,7 @@ import com.kunzisoft.keepass.model.GroupInfo
 import com.kunzisoft.keepass.model.NodeInfo
 import com.kunzisoft.keepass.model.RegisterInfo
 import com.kunzisoft.keepass.model.SearchInfo
+import com.kunzisoft.keepass.services.DatabaseTaskNotificationService
 import com.kunzisoft.keepass.services.DatabaseTaskNotificationService.Companion.ACTION_DATABASE_COPY_NODES_TASK
 import com.kunzisoft.keepass.services.DatabaseTaskNotificationService.Companion.ACTION_DATABASE_MOVE_NODES_TASK
 import com.kunzisoft.keepass.services.DatabaseTaskNotificationService.Companion.ACTION_DATABASE_TOUCH_ENTRY_TASK
@@ -163,6 +168,9 @@ class GroupActivity : DatabaseLockActivity() {
 
     // Manage merge
     private var mExternalFileHelper: ExternalFileHelper? = null
+    private var mKeeShareFileHelper: ExternalFileHelper? = null
+    private var mPendingKeeShareGroupId: String? = null
+    private var mKeeShareObserver: KeeShareObserver? = null
 
 
     private val mEntryActivityResultLauncher = EntryEditActivity.registerForEntryResult(this) { entryId ->
@@ -337,6 +345,18 @@ class GroupActivity : DatabaseLockActivity() {
         mExternalFileHelper?.buildCreateDocument("application/x-keepass") { uri ->
             uri?.let {
                 saveDatabaseTo(it)
+            }
+        }
+
+        mKeeShareFileHelper = ExternalFileHelper(this)
+        mKeeShareFileHelper?.buildOpenDocument { uri ->
+            uri?.let { selectedUri ->
+                mPendingKeeShareGroupId?.let { groupId ->
+                    contentResolver?.takeUriPermission(selectedUri)
+                    PreferencesUtil.setKeeShareContainerUri(this, groupId, selectedUri.toString())
+                    mPendingKeeShareGroupId = null
+                    mDatabaseViewModel.database?.let { startKeeShareObservers(it) }
+                }
             }
         }
 
@@ -599,6 +619,10 @@ class GroupActivity : DatabaseLockActivity() {
                             is GroupViewModel.GroupEvent.ScrollTo -> {
                                 addNodeButtonView?.hideOrShowButtonOnScrollListener(event.dy)
                             }
+                            is GroupViewModel.GroupEvent.KeeShareClicked -> {
+                                mPendingKeeShareGroupId = event.groupId.toString()
+                                mKeeShareFileHelper?.openDocument()
+                            }
                             is GroupViewModel.GroupEvent.HideKeyboard -> {
                                 hideKeyboard()
                             }
@@ -785,6 +809,7 @@ class GroupActivity : DatabaseLockActivity() {
 
     override fun onDatabaseRetrieved(database: ContextualDatabase) {
         super.onDatabaseRetrieved(database)
+        startKeeShareObservers(database)
 
         mGroupViewModel.onDatabaseLoaded(database)
 
@@ -840,6 +865,10 @@ class GroupActivity : DatabaseLockActivity() {
         actionTask: String,
         result: ActionRunnable.Result
     ) {
+        if (actionTask == DatabaseTaskNotificationService.ACTION_KEESHARE_MERGE_TASK) {
+            if (result.isSuccess) loadGroup()
+            return
+        }
         super.onDatabaseActionFinished(database, actionTask, result)
         when (actionTask) {
             ACTION_DATABASE_UPDATE_ENTRY_TASK -> {
@@ -1045,6 +1074,12 @@ class GroupActivity : DatabaseLockActivity() {
         toolbarAction?.updateButtonPaddingStart()
 
         loadGroup()
+    }
+
+    override fun onPause() {
+        super.onPause()
+        mKeeShareObserver?.stopAll(contentResolver)
+        mKeeShareObserver = null
     }
 
     private fun prepareDatabaseNavMenu() {
@@ -1254,6 +1289,47 @@ class GroupActivity : DatabaseLockActivity() {
                 super.onRegularBackPressed()
             }
         }
+    }
+
+    // KeeShare
+
+    private data class KeeShareConfig(
+        val containerUri: Uri,
+        val password: String,
+        val groupId: com.kunzisoft.keepass.database.element.GroupId,
+    )
+
+    private val mKeeShareConfigs = mutableMapOf<String, KeeShareConfig>()
+    private var mKeeShareInitialMergeDone = false
+
+    private fun startKeeShareObservers(database: ContextualDatabase) {
+        mKeeShareObserver?.stopAll(contentResolver)
+        if (!database.supportsKeeShare) return
+        mKeeShareObserver = KeeShareObserver { containerUri ->
+            mergeKeeShareContainer(containerUri.toString())
+        }
+        database.forEachGroupWithCustomData { group ->
+            val ref = KeeShareReference.fromCustomData(group.customData) ?: return@forEachGroupWithCustomData
+            val uriString = PreferencesUtil.getKeeShareContainerUri(this, group.nodeId.toString())
+                ?: return@forEachGroupWithCustomData
+            mKeeShareConfigs[uriString] = KeeShareConfig(Uri.parse(uriString), ref.password, group.nodeId)
+            mKeeShareObserver?.observe(contentResolver, Uri.parse(uriString))
+            if (!mKeeShareInitialMergeDone) {
+                mergeKeeShareContainer(uriString)
+            }
+        }
+        if (mKeeShareConfigs.isNotEmpty()) mKeeShareInitialMergeDone = true
+    }
+
+    private fun mergeKeeShareContainer(uriString: String) {
+        val config = mKeeShareConfigs[uriString] ?: return
+        mDatabaseViewModel.mergeKeeShare(
+            config.containerUri,
+            MainCredential(
+                if (config.password.isNotEmpty()) config.password.toCharArray() else CharArray(0),
+            ),
+            config.groupId,
+        )
     }
 
     companion object {

--- a/app/src/main/java/com/kunzisoft/keepass/activities/fragments/GroupFragment.kt
+++ b/app/src/main/java/com/kunzisoft/keepass/activities/fragments/GroupFragment.kt
@@ -38,6 +38,7 @@ import com.kunzisoft.keepass.credentialprovider.SpecialMode
 import com.kunzisoft.keepass.database.ContextualDatabase
 import com.kunzisoft.keepass.database.element.SortNodeEnum
 import com.kunzisoft.keepass.model.SearchGroupInfo
+import com.kunzisoft.keepass.model.SortedGroupInfo
 import com.kunzisoft.keepass.model.SortedNodeInfo
 import com.kunzisoft.keepass.viewmodels.GroupViewModel
 import kotlinx.coroutines.launch
@@ -86,6 +87,11 @@ class GroupFragment : DatabaseFragment() {
                     override fun onNodeLongClick(node: SortedNodeInfo): Boolean {
                         mGroupViewModel.performLongNodeClick(node)
                         return true
+                    }
+                })
+                setOnKeeShareClickListener(object : NodesAdapter.KeeShareClickCallback {
+                    override fun onKeeShareIconClick(node: SortedGroupInfo) {
+                        mGroupViewModel.performKeeShareClick(node)
                     }
                 })
                 setActionNodes(mGroupViewModel.actionsNodes.value)

--- a/app/src/main/java/com/kunzisoft/keepass/adapters/NodesAdapter.kt
+++ b/app/src/main/java/com/kunzisoft/keepass/adapters/NodesAdapter.kt
@@ -45,6 +45,7 @@ import com.kunzisoft.keepass.model.GroupInfo
 import com.kunzisoft.keepass.model.SortedEntryInfo
 import com.kunzisoft.keepass.model.SortedGroupInfo
 import com.kunzisoft.keepass.model.SortedNodeInfo
+import com.kunzisoft.keepass.database.keeshare.KeeShareReference
 import com.kunzisoft.keepass.settings.PreferencesUtil
 import com.kunzisoft.keepass.view.OtpDisplayView
 import com.kunzisoft.keepass.view.setTextSize
@@ -88,6 +89,7 @@ class NodesAdapter(
     private var mActionNodesList = mutableListOf<SortedNodeInfo>()
     private var mActionNodeIds = mutableSetOf<NodeId<*>>()
     private var mNodeClickCallback: NodeClickCallback? = null
+    private var mKeeShareClickCallback: KeeShareClickCallback? = null
 
     @ColorInt
     private val mColorSurfaceContainer: Int
@@ -440,6 +442,22 @@ class NodesAdapter(
             } else {
                 holder.numberChildren?.visibility = View.GONE
             }
+            holder.keeShareIcon?.apply {
+                val ref = KeeShareReference.fromCustomData(node.customData)
+                if (ref != null) {
+                    visibility = View.VISIBLE
+                    val configured = PreferencesUtil.getKeeShareContainerUri(
+                        context, node.nodeId.toString()
+                    ) != null
+                    setColorFilter(if (configured) iconColor else Color.RED)
+                    setOnClickListener {
+                        mKeeShareClickCallback?.onKeeShareIconClick(node)
+                    }
+                } else {
+                    visibility = View.GONE
+                    setOnClickListener(null)
+                }
+            }
         }
 
         // Assign image
@@ -489,12 +507,17 @@ class NodesAdapter(
         this.mNodeClickCallback = nodeClickCallback
     }
 
-    /**
-     * Callback listener to redefine to do an action when a node is clicked
-     */
+    fun setOnKeeShareClickListener(callback: KeeShareClickCallback?) {
+        this.mKeeShareClickCallback = callback
+    }
+
     interface NodeClickCallback {
         fun onNodeClick(node: SortedNodeInfo)
         fun onNodeLongClick(node: SortedNodeInfo): Boolean
+    }
+
+    interface KeeShareClickCallback {
+        fun onKeeShareIconClick(node: SortedGroupInfo)
     }
 
     class NodeViewHolder(itemView: View) : RecyclerView.ViewHolder(itemView) {
@@ -510,6 +533,7 @@ class NodesAdapter(
         var numberChildren: TextView? = itemView.findViewById(R.id.node_child_numbers)
         var attachmentIcon: ImageView? = itemView.findViewById(R.id.node_attachment_icon)
         var passkeyIcon: ImageView? = itemView.findViewById(R.id.node_passkey_icon)
+        var keeShareIcon: ImageView? = itemView.findViewById(R.id.node_keeshare_icon)
     }
 
     companion object {

--- a/app/src/main/java/com/kunzisoft/keepass/database/DatabaseTaskProvider.kt
+++ b/app/src/main/java/com/kunzisoft/keepass/database/DatabaseTaskProvider.kt
@@ -309,6 +309,18 @@ class DatabaseTaskProvider(
         }, ACTION_DATABASE_MERGE_TASK)
     }
 
+    fun startKeeShareMerge(
+        containerUri: Uri,
+        mainCredential: MainCredential,
+        targetGroupId: com.kunzisoft.keepass.database.element.GroupId,
+    ) {
+        start(Bundle().apply {
+            putParcelable(DatabaseTaskNotificationService.DATABASE_URI_KEY, containerUri)
+            putParcelable(DatabaseTaskNotificationService.MAIN_CREDENTIAL_KEY, mainCredential)
+            putParcelable(DatabaseTaskNotificationService.TARGET_GROUP_ID_KEY, targetGroupId)
+        }, DatabaseTaskNotificationService.ACTION_KEESHARE_MERGE_TASK)
+    }
+
     fun startDatabaseReload(fixDuplicateUuid: Boolean) {
         start(Bundle().apply {
             putBoolean(DatabaseTaskNotificationService.FIX_DUPLICATE_UUID_KEY, fixDuplicateUuid)

--- a/app/src/main/java/com/kunzisoft/keepass/database/action/MergeDatabaseRunnable.kt
+++ b/app/src/main/java/com/kunzisoft/keepass/database/action/MergeDatabaseRunnable.kt
@@ -40,6 +40,8 @@ class MergeDatabaseRunnable(
     save: Boolean,
     challengeResponseRetriever: (HardwareKey, ByteArray?) -> ByteArray,
     private val progressTaskUpdater: ProgressTaskUpdater?,
+    private val mTargetGroupId: com.kunzisoft.keepass.database.element.GroupId? = null,
+    private val mSilent: Boolean = false,
 ) : SaveDatabaseRunnable(
     context,
     database,
@@ -51,7 +53,7 @@ class MergeDatabaseRunnable(
     private var mMergeMasterCredential: MasterCredential? = null
 
     override fun onStartRun() {
-        database.wasReloaded = true
+        if (!mSilent) database.wasReloaded = true
         super.onStartRun()
     }
 
@@ -59,6 +61,7 @@ class MergeDatabaseRunnable(
         try {
             val contentResolver = context.contentResolver
             mMergeMasterCredential = mDatabaseToMergeMainCredential?.toMasterCredential(contentResolver)
+            val targetGroup = mTargetGroupId?.let { database.getGroupById(it) }
             database.mergeData(
                 databaseToMergeStream = contentResolver.getUriInputStream(
                     mDatabaseToMergeUri ?: database.fileUri
@@ -68,7 +71,8 @@ class MergeDatabaseRunnable(
                 isRAMSufficient = { memoryWanted ->
                     BinaryData.canMemoryBeAllocatedInRAM(context, memoryWanted)
                 },
-                progressTaskUpdater = progressTaskUpdater
+                progressTaskUpdater = progressTaskUpdater,
+                targetGroup = targetGroup,
             )
         } catch (e: DatabaseException) {
             setError(e)

--- a/app/src/main/java/com/kunzisoft/keepass/keeshare/KeeShareObserver.kt
+++ b/app/src/main/java/com/kunzisoft/keepass/keeshare/KeeShareObserver.kt
@@ -1,0 +1,74 @@
+/*
+ * Copyright 2026 Jeremy Jamet / Kunzisoft.
+ *
+ * This file is part of KeePassDX.
+ *
+ *  KeePassDX is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  KeePassDX is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with KeePassDX.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+package com.kunzisoft.keepass.keeshare
+
+import android.content.ContentResolver
+import android.database.ContentObserver
+import android.net.Uri
+import android.os.Handler
+import android.os.Looper
+import android.util.Log
+
+/** Watches SAF URIs for changes to KeeShare container files via ContentObserver. */
+class KeeShareObserver(private val onChange: (Uri) -> Unit) {
+
+    private val observers = mutableMapOf<Uri, ContentObserver>()
+
+    /** Start observing [uri]. Replaces any existing observer for the same URI. */
+    fun observe(contentResolver: ContentResolver, uri: Uri) {
+        stop(contentResolver, uri)
+        val observer = object : ContentObserver(Handler(Looper.getMainLooper())) {
+            override fun onChange(selfChange: Boolean) {
+                onChange(uri)
+            }
+        }
+        try {
+            contentResolver.registerContentObserver(uri, true, observer)
+            observers[uri] = observer
+        } catch (e: Exception) {
+            Log.e(TAG, "Failed to register ContentObserver for $uri", e)
+        }
+    }
+
+    fun stop(contentResolver: ContentResolver, uri: Uri) {
+        observers.remove(uri)?.let {
+            try {
+                contentResolver.unregisterContentObserver(it)
+            } catch (e: Exception) {
+                Log.e(TAG, "Failed to unregister ContentObserver", e)
+            }
+        }
+    }
+
+    fun stopAll(contentResolver: ContentResolver) {
+        observers.values.forEach {
+            try {
+                contentResolver.unregisterContentObserver(it)
+            } catch (e: Exception) {
+                Log.e(TAG, "Failed to unregister ContentObserver", e)
+            }
+        }
+        observers.clear()
+    }
+
+    companion object {
+        private val TAG = KeeShareObserver::class.java.name
+    }
+}

--- a/app/src/main/java/com/kunzisoft/keepass/services/DatabaseTaskNotificationService.kt
+++ b/app/src/main/java/com/kunzisoft/keepass/services/DatabaseTaskNotificationService.kt
@@ -344,6 +344,7 @@ open class DatabaseTaskNotificationService : LockNotificationService(), Progress
             ACTION_DATABASE_CREATE_TASK -> buildDatabaseCreateActionTask(intent, database)
             ACTION_DATABASE_LOAD_TASK -> buildDatabaseLoadActionTask(intent, database)
             ACTION_DATABASE_MERGE_TASK -> buildDatabaseMergeActionTask(intent, database)
+            ACTION_KEESHARE_MERGE_TASK -> buildKeeShareMergeActionTask(intent, database)
             ACTION_DATABASE_RELOAD_TASK -> buildDatabaseReloadActionTask(database)
             ACTION_DATABASE_ASSIGN_CREDENTIAL_TASK -> buildDatabaseAssignCredentialActionTask(intent, database)
             ACTION_DATABASE_CREATE_GROUP_TASK -> buildDatabaseCreateGroupActionTask(intent, database)
@@ -380,6 +381,7 @@ open class DatabaseTaskNotificationService : LockNotificationService(), Progress
 
         // Sub action is an action in another action, don't perform pre and post action
         val isMainAction = intentAction != ACTION_CHALLENGE_RESPONDED
+                && intentAction != ACTION_KEESHARE_MERGE_TASK
 
         // Build and launch the action
         if (actionRunnable != null) {
@@ -409,16 +411,16 @@ open class DatabaseTaskNotificationService : LockNotificationService(), Progress
                         actionRunnable
                     },
                     { result ->
+                        mActionTaskListeners.forEach { actionTaskListener ->
+                            actionTaskListener.onActionFinished(
+                                database,
+                                intentAction!!,
+                                result
+                            )
+                        }
                         if (isMainAction) {
                             try {
-                                mActionTaskListeners.forEach { actionTaskListener ->
-                                    mTaskRemovedRequested = false
-                                    actionTaskListener.onActionFinished(
-                                        database,
-                                        intentAction!!,
-                                        result
-                                    )
-                                }
+                                mTaskRemovedRequested = false
                             } finally {
                                 // Save the database info after performing action
                                 val save = !database.isReadOnly
@@ -904,6 +906,22 @@ open class DatabaseTaskNotificationService : LockNotificationService(), Progress
         }
     }
 
+    private fun buildKeeShareMergeActionTask(
+        intent: Intent,
+        database: ContextualDatabase,
+    ): ActionRunnable {
+        val containerUri: Uri? = intent.getParcelableExtraCompat(DATABASE_URI_KEY)
+        val mainCredential: MainCredential? = intent.getParcelableExtraCompat(MAIN_CREDENTIAL_KEY)
+        val targetGroupId: GroupId? = intent.getParcelableExtraCompat(TARGET_GROUP_ID_KEY)
+        return MergeDatabaseRunnable(
+            this, containerUri, mainCredential,
+            { hardwareKey, seed -> retrieveResponseFromChallenge(hardwareKey, seed) },
+            database, false,
+            { hardwareKey, seed -> retrieveResponseFromChallenge(hardwareKey, seed) },
+            null, targetGroupId, true,
+        )
+    }
+
     private fun buildDatabaseReloadActionTask(
         database: ContextualDatabase
     ): ActionRunnable {
@@ -1386,6 +1404,8 @@ open class DatabaseTaskNotificationService : LockNotificationService(), Progress
         const val ACTION_DATABASE_CREATE_TASK = "ACTION_DATABASE_CREATE_TASK"
         const val ACTION_DATABASE_LOAD_TASK = "ACTION_DATABASE_LOAD_TASK"
         const val ACTION_DATABASE_MERGE_TASK = "ACTION_DATABASE_MERGE_TASK"
+        const val ACTION_KEESHARE_MERGE_TASK = "ACTION_KEESHARE_MERGE_TASK"
+        const val TARGET_GROUP_ID_KEY = "TARGET_GROUP_ID_KEY"
         const val ACTION_DATABASE_RELOAD_TASK = "ACTION_DATABASE_RELOAD_TASK"
         const val ACTION_DATABASE_ASSIGN_CREDENTIAL_TASK = "ACTION_DATABASE_ASSIGN_CREDENTIAL_TASK"
         const val ACTION_DATABASE_CREATE_GROUP_TASK = "ACTION_DATABASE_CREATE_GROUP_TASK"

--- a/app/src/main/java/com/kunzisoft/keepass/settings/PreferencesUtil.kt
+++ b/app/src/main/java/com/kunzisoft/keepass/settings/PreferencesUtil.kt
@@ -1018,4 +1018,21 @@ object PreferencesUtil {
             Education.putPropertiesInEducationPreferences(context, editor, name, value)
         }
     }
+
+    private const val KEESHARE_CONTAINER_PREFIX = "keeshare_container_"
+
+    /** Store the SAF URI for a KeeShare container associated with a group. */
+    fun setKeeShareContainerUri(context: Context, groupId: String, uri: String?) {
+        PreferenceManager.getDefaultSharedPreferences(context).edit().apply {
+            if (uri != null) putString(KEESHARE_CONTAINER_PREFIX + groupId, uri)
+            else remove(KEESHARE_CONTAINER_PREFIX + groupId)
+            apply()
+        }
+    }
+
+    /** Retrieve the SAF URI for a KeeShare container associated with a group. */
+    fun getKeeShareContainerUri(context: Context, groupId: String): String? {
+        return PreferenceManager.getDefaultSharedPreferences(context)
+            .getString(KEESHARE_CONTAINER_PREFIX + groupId, null)
+    }
 }

--- a/app/src/main/java/com/kunzisoft/keepass/viewmodels/DatabaseViewModel.kt
+++ b/app/src/main/java/com/kunzisoft/keepass/viewmodels/DatabaseViewModel.kt
@@ -181,6 +181,15 @@ class DatabaseViewModel(application: Application): AndroidViewModel(application)
         mDatabaseTaskProvider.startDatabaseMerge(save, fromDatabaseUri, mainCredential)
     }
 
+    /** Silent scoped merge for KeeShare container import. */
+    fun mergeKeeShare(
+        containerUri: Uri,
+        mainCredential: MainCredential,
+        targetGroupId: GroupId,
+    ) {
+        mDatabaseTaskProvider.startKeeShareMerge(containerUri, mainCredential, targetGroupId)
+    }
+
     fun reloadDatabase(fixDuplicateUuid: Boolean, forceReload: Boolean = false) {
         if (!forceReload && database?.dataModifiedSinceLastLoading == true) {
             mActionState.value = ActionState.ShowDatabaseInfoReloadedDialog(fixDuplicateUuid)

--- a/app/src/main/java/com/kunzisoft/keepass/viewmodels/GroupViewModel.kt
+++ b/app/src/main/java/com/kunzisoft/keepass/viewmodels/GroupViewModel.kt
@@ -309,6 +309,12 @@ class GroupViewModel(application: Application): AndroidViewModel(application) {
         }
     }
 
+    fun performKeeShareClick(node: SortedGroupInfo) {
+        viewModelScope.launch {
+            _viewEvent.emit(GroupEvent.KeeShareClicked(node.nodeId))
+        }
+    }
+
     fun performLongNodeClick(node: SortedNodeInfo): Boolean {
         viewModelScope.launch {
             val state = nodeActionState.value
@@ -550,6 +556,7 @@ class GroupViewModel(application: Application): AndroidViewModel(application) {
         data class ScrollTo(val dy: Int) : GroupEvent()
         data class SortSelected(val sortNode: SortNode) : GroupEvent()
         object ClearSearch : GroupEvent()
+        data class KeeShareClicked(val groupId: GroupId) : GroupEvent()
     }
 
     data class DeleteActionState(

--- a/app/src/main/res/layout/item_list_nodes_group.xml
+++ b/app/src/main/res/layout/item_list_nodes_group.xml
@@ -108,6 +108,16 @@
         </LinearLayout>
 
         <androidx.appcompat.widget.AppCompatImageView
+            android:id="@+id/node_keeshare_icon"
+            android:layout_width="16dp"
+            android:layout_height="16dp"
+            android:layout_toStartOf="@+id/node_image_identifier"
+            android:layout_toLeftOf="@+id/node_image_identifier"
+            android:layout_centerVertical="true"
+            android:src="@drawable/ic_share_white_24dp"
+            android:visibility="gone" />
+
+        <androidx.appcompat.widget.AppCompatImageView
             android:id="@+id/node_image_identifier"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"

--- a/app/src/test/kotlin/com/kunzisoft/keepass/keeshare/KeeSharePreferencesTest.kt
+++ b/app/src/test/kotlin/com/kunzisoft/keepass/keeshare/KeeSharePreferencesTest.kt
@@ -1,0 +1,75 @@
+/*
+ * Copyright 2026 Jeremy Jamet / Kunzisoft.
+ *
+ * This file is part of KeePassDX.
+ *
+ *  KeePassDX is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  KeePassDX is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with KeePassDX.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+package com.kunzisoft.keepass.keeshare
+
+import com.kunzisoft.keepass.settings.PreferencesUtil
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.RuntimeEnvironment
+import org.robolectric.annotation.Config
+
+@RunWith(RobolectricTestRunner::class)
+@Config(sdk = [34])
+class KeeSharePreferencesTest {
+
+    private val context get() = RuntimeEnvironment.getApplication()
+
+    @Test
+    fun storeAndRetrieveContainerUri() {
+        val uuid = "550e8400-e29b-41d4-a716-446655440000"
+        val uri = "content://com.android.providers.downloads.documents/tree/raw%3A%2Fsync%2Fshared.kdbx"
+        PreferencesUtil.setKeeShareContainerUri(context, uuid, uri)
+        assertEquals(uri, PreferencesUtil.getKeeShareContainerUri(context, uuid))
+    }
+
+    @Test
+    fun returnNullForUnknownGroup() {
+        assertNull(PreferencesUtil.getKeeShareContainerUri(context, "nonexistent-uuid"))
+    }
+
+    @Test
+    fun removeContainerUri() {
+        val uuid = "test-uuid"
+        PreferencesUtil.setKeeShareContainerUri(context, uuid, "content://test")
+        PreferencesUtil.setKeeShareContainerUri(context, uuid, null)
+        assertNull(PreferencesUtil.getKeeShareContainerUri(context, uuid))
+    }
+
+    @Test
+    fun multipleGroupsStoredIndependently() {
+        val uuid1 = "uuid-1"
+        val uuid2 = "uuid-2"
+        PreferencesUtil.setKeeShareContainerUri(context, uuid1, "content://file1")
+        PreferencesUtil.setKeeShareContainerUri(context, uuid2, "content://file2")
+        assertEquals("content://file1", PreferencesUtil.getKeeShareContainerUri(context, uuid1))
+        assertEquals("content://file2", PreferencesUtil.getKeeShareContainerUri(context, uuid2))
+    }
+
+    @Test
+    fun overwriteExistingUri() {
+        val uuid = "overwrite-uuid"
+        PreferencesUtil.setKeeShareContainerUri(context, uuid, "content://old")
+        PreferencesUtil.setKeeShareContainerUri(context, uuid, "content://new")
+        assertEquals("content://new", PreferencesUtil.getKeeShareContainerUri(context, uuid))
+    }
+}

--- a/database/build.gradle
+++ b/database/build.gradle
@@ -9,6 +9,7 @@ android {
     defaultConfig {
         minSdkVersion 19
         targetSdk 35
+        multiDexEnabled true
 
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
     }
@@ -49,7 +50,7 @@ dependencies {
     api project(path: ':crypto')
 
     // Tests
-    androidTestImplementation "androidx.test:runner:$android_test_version"
+    androidTestImplementation "androidx.test:runner:1.6.2"
     testImplementation "junit:junit:4.13.2"
     testImplementation "org.robolectric:robolectric:4.11.1"
 }

--- a/database/src/androidTest/java/com/kunzisoft/keepass/tests/keeshare/KeeShareMergeTest.kt
+++ b/database/src/androidTest/java/com/kunzisoft/keepass/tests/keeshare/KeeShareMergeTest.kt
@@ -1,0 +1,177 @@
+/*
+ * Copyright 2026 Jeremy Jamet / Kunzisoft.
+ *
+ * This file is part of KeePassDX.
+ *
+ *  KeePassDX is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  KeePassDX is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with KeePassDX.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+package com.kunzisoft.keepass.tests.keeshare
+
+import androidx.test.platform.app.InstrumentationRegistry
+import com.kunzisoft.keepass.database.element.Database
+import com.kunzisoft.keepass.database.element.Entry
+import com.kunzisoft.keepass.database.element.Group
+import com.kunzisoft.keepass.database.element.MasterCredential
+import com.kunzisoft.keepass.database.element.node.NodeHandler
+import com.kunzisoft.keepass.database.keeshare.KeeShareReference
+import com.kunzisoft.keepass.hardware.HardwareKey
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+import java.io.File
+class KeeShareMergeTest {
+
+    private lateinit var db: Database
+    private lateinit var cacheDir: File
+    private val password = "testpass"
+    private val noOpChallengeResponse: (HardwareKey, ByteArray?) -> ByteArray = { _, _ -> ByteArray(0) }
+
+    @Before
+    fun setUp() {
+        cacheDir = File(
+            InstrumentationRegistry.getInstrumentation().targetContext.cacheDir,
+            "keeshare_test"
+        ).apply { mkdirs() }
+        db = TestDatabaseBuilder.createMainDatabase(cacheDir, password)
+    }
+
+    private fun collectEntryTitles(group: Group?): List<String> {
+        val titles = mutableListOf<String>()
+        group?.doForEachChild(
+            object : NodeHandler<Entry>() {
+                override fun operate(node: Entry): Boolean {
+                    titles.add(node.title)
+                    return true
+                }
+            },
+            null
+        )
+        return titles
+    }
+
+    private fun mergeContainer(targetGroup: Group?) {
+        val containerFile = TestDatabaseBuilder.saveToFile(
+            TestDatabaseBuilder.createContainer(cacheDir, password, db),
+            cacheDir, password, "container.kdbx"
+        )
+        try {
+            db.mergeData(
+                containerFile.inputStream(),
+                MasterCredential(password.toCharArray()),
+                noOpChallengeResponse,
+                isRAMSufficient = { true },
+                progressTaskUpdater = null,
+                targetGroup = targetGroup
+            )
+        } finally {
+            containerFile.delete()
+        }
+    }
+
+    @Test
+    fun databaseLoadsWithGroups() {
+        assertTrue(db.loaded)
+        assertNotNull(db.rootGroup)
+        val names = db.getAllGroupsWithoutRoot().map { it.title }
+        assertTrue(names.contains("SharedGroup"))
+        assertTrue(names.contains("NormalGroup"))
+    }
+
+    @Test
+    fun sharedGroupHasKeeShareReference() {
+        val shared = db.getAllGroupsWithoutRoot().find { it.title == "SharedGroup" }
+        assertNotNull(shared)
+        val ref = KeeShareReference.fromCustomData(shared!!.customData)
+        assertNotNull(ref)
+        assertTrue(ref!!.isImporting)
+        assertTrue(ref.isExporting)
+    }
+
+    @Test
+    fun normalGroupHasNoKeeShareReference() {
+        val normal = db.getAllGroupsWithoutRoot().find { it.title == "NormalGroup" }
+        assertNotNull(normal)
+        assertTrue(KeeShareReference.fromCustomData(normal!!.customData) == null)
+    }
+
+    @Test
+    fun sharedGroupDetectedByForEachGroupWithCustomData() {
+        val found = mutableListOf<String>()
+        db.forEachGroupWithCustomData { found.add(it.title) }
+        assertTrue(found.contains("SharedGroup"))
+        assertTrue(!found.contains("NormalGroup"))
+    }
+
+    @Test
+    fun mergeContainerAddsNewEntry() {
+        val shared = db.getAllGroupsWithoutRoot().find { it.title == "SharedGroup" }
+        mergeContainer(shared)
+
+        val sharedEntries = collectEntryTitles(
+            db.getAllGroupsWithoutRoot().find { it.title == "SharedGroup" }
+        )
+        assertTrue("DesktopNewEntry should appear in SharedGroup", sharedEntries.contains("DesktopNewEntry"))
+    }
+
+    @Test
+    fun mergeContainerPreservesExistingEntries() {
+        val shared = db.getAllGroupsWithoutRoot().find { it.title == "SharedGroup" }
+        val beforeEntries = collectEntryTitles(shared)
+        mergeContainer(shared)
+
+        val afterEntries = collectEntryTitles(
+            db.getAllGroupsWithoutRoot().find { it.title == "SharedGroup" }
+        )
+        for (entry in beforeEntries) {
+            assertTrue("$entry should still exist after merge", afterEntries.contains(entry))
+        }
+    }
+
+    @Test
+    fun mergeContainerDoesNotDuplicateNormalGroupEntries() {
+        val normalBefore = collectEntryTitles(
+            db.getAllGroupsWithoutRoot().find { it.title == "NormalGroup" }
+        )
+        val shared = db.getAllGroupsWithoutRoot().find { it.title == "SharedGroup" }
+        mergeContainer(shared)
+
+        val normalAfter = collectEntryTitles(
+            db.getAllGroupsWithoutRoot().find { it.title == "NormalGroup" }
+        )
+        assertEquals("NormalGroup should be unchanged", normalBefore, normalAfter)
+    }
+
+    @Test
+    fun mergeContainerDoesNotDuplicateSharedEntries() {
+        val shared = db.getAllGroupsWithoutRoot().find { it.title == "SharedGroup" }
+        val sharedBefore = collectEntryTitles(shared)
+        mergeContainer(shared)
+
+        val sharedAfter = collectEntryTitles(
+            db.getAllGroupsWithoutRoot().find { it.title == "SharedGroup" }
+        )
+        for (entry in sharedBefore) {
+            val countBefore = sharedBefore.count { it == entry }
+            val countAfter = sharedAfter.count { it == entry }
+            assertEquals(
+                "$entry should not be duplicated (before=$countBefore, after=$countAfter)",
+                countBefore, countAfter
+            )
+        }
+        assertTrue("DesktopNewEntry should appear in SharedGroup", sharedAfter.contains("DesktopNewEntry"))
+    }
+}

--- a/database/src/androidTest/java/com/kunzisoft/keepass/tests/keeshare/TestDatabaseBuilder.kt
+++ b/database/src/androidTest/java/com/kunzisoft/keepass/tests/keeshare/TestDatabaseBuilder.kt
@@ -1,0 +1,112 @@
+/*
+ * Copyright 2026 Jeremy Jamet / Kunzisoft.
+ *
+ * This file is part of KeePassDX.
+ *
+ *  KeePassDX is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  KeePassDX is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with KeePassDX.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+package com.kunzisoft.keepass.tests.keeshare
+
+import com.kunzisoft.keepass.database.element.CustomData
+import com.kunzisoft.keepass.database.element.CustomDataItem
+import com.kunzisoft.keepass.database.element.Database
+import com.kunzisoft.keepass.database.element.Entry
+import com.kunzisoft.keepass.database.element.Group
+import com.kunzisoft.keepass.database.element.MasterCredential
+import com.kunzisoft.keepass.database.keeshare.KeeShareReference
+import com.kunzisoft.keepass.hardware.HardwareKey
+import java.io.File
+
+object TestDatabaseBuilder {
+
+    private val noOpChallengeResponse: (HardwareKey, ByteArray?) -> ByteArray = { _, _ -> ByteArray(0) }
+
+    private fun addEntry(db: Database, parent: Group, title: String, user: String, pass: String, url: String = "") {
+        val entry: Entry = db.createEntry() ?: return
+        entry.title = title
+        entry.username = user
+        entry.password = pass.toCharArray()
+        if (url.isNotEmpty()) entry.url = url
+        db.addEntryTo(entry, parent)
+    }
+
+    fun createMainDatabase(cacheDir: File, password: String): Database {
+        val db = Database()
+        db.createData("TestDB", "Root", null)
+        val root = db.rootGroup!!
+
+        val shared: Group = db.createGroup()!!
+        shared.title = "SharedGroup"
+        db.addGroupTo(shared, root)
+
+        val ref = KeeShareReference(type = KeeShareReference.SYNCHRONIZE, path = "/Sync/shared.kdbx")
+        shared.customData = CustomData().apply {
+            put(CustomDataItem(KeeShareReference.CUSTOM_DATA_KEY, ref.serialize()))
+        }
+
+        addEntry(db, shared, "TestEntry", "testuser", "testpass123", "https://example.com")
+        addEntry(db, shared, "SharedEntry2", "shareduser2", "sharedpass2")
+
+        val normal: Group = db.createGroup()!!
+        normal.title = "NormalGroup"
+        db.addGroupTo(normal, root)
+
+        addEntry(db, normal, "NormalEntry1", "user1", "pass1")
+        addEntry(db, normal, "NormalEntry2", "user2", "pass2")
+
+        return saveAndReload(db, cacheDir, password)
+    }
+
+    fun createContainer(cacheDir: File, password: String, mainDb: Database): Database {
+        val db = Database()
+        db.createData("KeeShare", "Root", null)
+        val root = db.rootGroup!!
+
+        val shared = mainDb.getAllGroupsWithoutRoot().find { it.title == "SharedGroup" }
+        shared?.getChildEntries()?.forEach { src ->
+            val copy: Entry = db.createEntry() ?: return@forEach
+            copy.nodeId = src.nodeId
+            copy.title = src.title
+            copy.username = src.username
+            copy.password = src.password
+            copy.url = src.url
+            copy.notes = src.notes
+            db.addEntryTo(copy, root)
+        }
+
+        addEntry(db, root, "DesktopNewEntry", "desktop_user", "desktop_pass", "https://added-on-desktop.com")
+
+        return saveAndReload(db, cacheDir, password)
+    }
+
+    fun saveToFile(db: Database, cacheDir: File, password: String, filename: String): File {
+        val outFile = File(cacheDir, filename)
+        val tmpFile = File(cacheDir, "$filename.tmp")
+        db.saveData(tmpFile, { outFile.outputStream() },
+            MasterCredential(password.toCharArray()), noOpChallengeResponse)
+        return outFile
+    }
+
+    private fun saveAndReload(db: Database, cacheDir: File, password: String): Database {
+        val file = saveToFile(db, cacheDir, password, "temp_${System.nanoTime()}.kdbx")
+        val reloaded = Database()
+        reloaded.loadData(file.inputStream(), MasterCredential(password.toCharArray()),
+            noOpChallengeResponse, readOnly = false, allowUserVerification = false,
+            cacheDirectory = cacheDir, isRAMSufficient = { true },
+            fixDuplicateUUID = false, progressTaskUpdater = null)
+        file.delete()
+        return reloaded
+    }
+}

--- a/database/src/androidTest/java/com/kunzisoft/keepass/tests/merge/ScopedMergeTest.kt
+++ b/database/src/androidTest/java/com/kunzisoft/keepass/tests/merge/ScopedMergeTest.kt
@@ -1,0 +1,224 @@
+/*
+ * Copyright 2026 Jeremy Jamet / Kunzisoft.
+ *
+ * This file is part of KeePassDX.
+ *
+ *  KeePassDX is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  KeePassDX is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with KeePassDX.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+package com.kunzisoft.keepass.tests.merge
+
+import androidx.test.platform.app.InstrumentationRegistry
+import com.kunzisoft.keepass.database.element.Database
+import com.kunzisoft.keepass.database.element.Entry
+import com.kunzisoft.keepass.database.element.Group
+import com.kunzisoft.keepass.database.element.MasterCredential
+import com.kunzisoft.keepass.database.element.node.NodeHandler
+import com.kunzisoft.keepass.hardware.HardwareKey
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+import java.io.File
+class ScopedMergeTest {
+
+    private lateinit var mainDb: Database
+    private lateinit var cacheDir: File
+    private val password = "testpass"
+    private val noOpChallengeResponse: (HardwareKey, ByteArray?) -> ByteArray = { _, _ -> ByteArray(0) }
+
+    private fun collectEntryTitles(group: Group?): List<String> {
+        val titles = mutableListOf<String>()
+        group?.doForEachChild(
+            object : NodeHandler<Entry>() {
+                override fun operate(node: Entry): Boolean {
+                    titles.add(node.title)
+                    return true
+                }
+            },
+            null,
+        )
+        return titles
+    }
+
+    private fun createAndSaveDb(name: String, vararg entries: Pair<String, String>): File {
+        val db = Database()
+        db.createData(name, "Root", null)
+        val root = db.rootGroup!!
+        for ((title, user) in entries) {
+            val entry: Entry = db.createEntry() ?: continue
+            entry.title = title
+            entry.username = user
+            entry.password = "pass".toCharArray()
+            db.addEntryTo(entry, root)
+        }
+        val file = File(cacheDir, "$name.kdbx")
+        val tmp = File(cacheDir, "$name.tmp")
+        db.saveData(tmp, { file.outputStream() },
+            MasterCredential(password.toCharArray()), noOpChallengeResponse)
+        db.clearAndClose()
+        return file
+    }
+
+    @Before
+    fun setUp() {
+        cacheDir = File(
+            InstrumentationRegistry.getInstrumentation().targetContext.cacheDir,
+            "scoped_merge_test",
+        ).apply { mkdirs() }
+
+        mainDb = Database()
+        mainDb.createData("MainDB", "Root", null)
+        val root = mainDb.rootGroup!!
+
+        val targetGroup: Group = mainDb.createGroup()!!
+        targetGroup.title = "TargetGroup"
+        mainDb.addGroupTo(targetGroup, root)
+
+        val otherGroup: Group = mainDb.createGroup()!!
+        otherGroup.title = "OtherGroup"
+        mainDb.addGroupTo(otherGroup, root)
+
+        val existingEntry: Entry = mainDb.createEntry()!!
+        existingEntry.title = "ExistingEntry"
+        existingEntry.username = "existing"
+        existingEntry.password = "pass".toCharArray()
+        mainDb.addEntryTo(existingEntry, otherGroup)
+
+        val file = File(cacheDir, "main.kdbx")
+        val tmp = File(cacheDir, "main.tmp")
+        mainDb.saveData(tmp, { file.outputStream() },
+            MasterCredential(password.toCharArray()), noOpChallengeResponse)
+
+        mainDb = Database()
+        mainDb.loadData(file.inputStream(), MasterCredential(password.toCharArray()),
+            noOpChallengeResponse, readOnly = false, allowUserVerification = false,
+            cacheDirectory = cacheDir, isRAMSufficient = { true },
+            fixDuplicateUUID = false, progressTaskUpdater = null)
+    }
+
+    @Test
+    fun unscopedMergePutsEntriesAtRoot() {
+        val containerFile = createAndSaveDb("container",
+            "NewEntry1" to "user1", "NewEntry2" to "user2")
+
+        mainDb.mergeData(
+            containerFile.inputStream(),
+            MasterCredential(password.toCharArray()),
+            noOpChallengeResponse,
+            isRAMSufficient = { true },
+            progressTaskUpdater = null,
+        )
+
+        val rootEntries = collectEntryTitles(mainDb.rootGroup)
+        assertTrue("NewEntry1 should be in database", rootEntries.contains("NewEntry1"))
+        assertTrue("NewEntry2 should be in database", rootEntries.contains("NewEntry2"))
+
+        val targetEntries = collectEntryTitles(
+            mainDb.getAllGroupsWithoutRoot().find { it.title == "TargetGroup" },
+        )
+        assertFalse("NewEntry1 should NOT be in TargetGroup", targetEntries.contains("NewEntry1"))
+    }
+
+    @Test
+    fun scopedMergePutsEntriesInTargetGroup() {
+        val target = mainDb.getAllGroupsWithoutRoot().find { it.title == "TargetGroup" }!!
+        val containerFile = createAndSaveDb("container",
+            "NewEntry1" to "user1", "NewEntry2" to "user2")
+
+        mainDb.mergeData(
+            containerFile.inputStream(),
+            MasterCredential(password.toCharArray()),
+            noOpChallengeResponse,
+            isRAMSufficient = { true },
+            progressTaskUpdater = null,
+            targetGroup = target,
+        )
+
+        val targetEntries = collectEntryTitles(target)
+        assertTrue("NewEntry1 should be in TargetGroup", targetEntries.contains("NewEntry1"))
+        assertTrue("NewEntry2 should be in TargetGroup", targetEntries.contains("NewEntry2"))
+    }
+
+    @Test
+    fun scopedMergeDoesNotAffectOtherGroups() {
+        val target = mainDb.getAllGroupsWithoutRoot().find { it.title == "TargetGroup" }!!
+        val otherBefore = collectEntryTitles(
+            mainDb.getAllGroupsWithoutRoot().find { it.title == "OtherGroup" },
+        )
+
+        val containerFile = createAndSaveDb("container", "NewEntry1" to "user1")
+
+        mainDb.mergeData(
+            containerFile.inputStream(),
+            MasterCredential(password.toCharArray()),
+            noOpChallengeResponse,
+            isRAMSufficient = { true },
+            progressTaskUpdater = null,
+            targetGroup = target,
+        )
+
+        val otherAfter = collectEntryTitles(
+            mainDb.getAllGroupsWithoutRoot().find { it.title == "OtherGroup" },
+        )
+        assertEquals("OtherGroup should be unchanged", otherBefore, otherAfter)
+    }
+
+    @Test
+    fun scopedMergePreservesExistingTargetEntries() {
+        val target = mainDb.getAllGroupsWithoutRoot().find { it.title == "TargetGroup" }!!
+
+        val preEntry: Entry = mainDb.createEntry()!!
+        preEntry.title = "PreExisting"
+        preEntry.username = "pre"
+        preEntry.password = "pass".toCharArray()
+        mainDb.addEntryTo(preEntry, target)
+
+        val containerFile = createAndSaveDb("container", "NewEntry1" to "user1")
+
+        mainDb.mergeData(
+            containerFile.inputStream(),
+            MasterCredential(password.toCharArray()),
+            noOpChallengeResponse,
+            isRAMSufficient = { true },
+            progressTaskUpdater = null,
+            targetGroup = target,
+        )
+
+        val targetEntries = collectEntryTitles(target)
+        assertTrue("PreExisting should still be there", targetEntries.contains("PreExisting"))
+        assertTrue("NewEntry1 should be added", targetEntries.contains("NewEntry1"))
+    }
+
+    @Test
+    fun scopedMergeWithEmptyContainer() {
+        val target = mainDb.getAllGroupsWithoutRoot().find { it.title == "TargetGroup" }!!
+        val beforeEntries = collectEntryTitles(target)
+
+        val containerFile = createAndSaveDb("empty_container")
+
+        mainDb.mergeData(
+            containerFile.inputStream(),
+            MasterCredential(password.toCharArray()),
+            noOpChallengeResponse,
+            isRAMSufficient = { true },
+            progressTaskUpdater = null,
+            targetGroup = target,
+        )
+
+        val afterEntries = collectEntryTitles(target)
+        assertEquals("TargetGroup should be unchanged", beforeEntries, afterEntries)
+    }
+}

--- a/database/src/main/java/com/kunzisoft/keepass/database/element/Database.kt
+++ b/database/src/main/java/com/kunzisoft/keepass/database/element/Database.kt
@@ -274,6 +274,10 @@ open class Database {
     val allowDataCompression: Boolean
         get() = mDatabaseKDBX != null
 
+    /** Whether this database format supports KeeShare (KDBX only). */
+    val supportsKeeShare: Boolean
+        get() = mDatabaseKDBX != null
+
     val availableCompressionAlgorithms: List<CompressionAlgorithm>
         get() = mDatabaseKDBX?.availableCompressionAlgorithms ?: emptyList()
 
@@ -432,6 +436,13 @@ open class Database {
         return mDatabaseKDB?.getAllGroupsWithoutRoot()?.map { Group(it) }
             ?: mDatabaseKDBX?.getAllGroupsWithoutRoot()?.map { Group(it) }
             ?: listOf()
+    }
+
+    /** Iterate all indexed groups that have non-empty custom data. */
+    fun forEachGroupWithCustomData(action: (Group) -> Unit) {
+        mDatabaseKDBX?.getGroupIndexes()
+            ?.filter { it.customData.isNotEmpty() }
+            ?.forEach { action(Group(it)) }
     }
 
     val manageHistory: Boolean
@@ -627,12 +638,18 @@ open class Database {
     }
 
     @Throws(DatabaseInputException::class)
+    /**
+     * Merge data from another database stream into this database.
+     * If [targetGroup] is set, entries from the source root are placed
+     * into that group instead of this database's root (scoped merge).
+     */
     fun mergeData(
         databaseToMergeStream: InputStream,
         databaseToMergeMasterCredential: MasterCredential?,
         databaseToMergeChallengeResponseRetriever: (HardwareKey, ByteArray?) -> ByteArray,
         isRAMSufficient: (memoryWanted: Long) -> Boolean,
-        progressTaskUpdater: ProgressTaskUpdater?
+        progressTaskUpdater: ProgressTaskUpdater?,
+        targetGroup: Group? = null,
     ) {
 
         mDatabaseKDB?.let {
@@ -684,6 +701,7 @@ open class Database {
             mDatabaseKDBX?.let { currentDatabaseKDBX ->
                 val databaseMerger = DatabaseKDBXMerger(currentDatabaseKDBX).apply {
                     this.isRAMSufficient = isRAMSufficient
+                    this.targetGroup = targetGroup?.groupKDBX
                 }
                 databaseToMerge.mDatabaseKDB?.let { databaseKDBToMerge ->
                     databaseMerger.merge(databaseKDBToMerge)

--- a/database/src/main/java/com/kunzisoft/keepass/database/keeshare/KeeShareReference.kt
+++ b/database/src/main/java/com/kunzisoft/keepass/database/keeshare/KeeShareReference.kt
@@ -1,0 +1,194 @@
+/*
+ * Copyright 2026 Jeremy Jamet / Kunzisoft.
+ *
+ * This file is part of KeePassDX.
+ *
+ *  KeePassDX is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  KeePassDX is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with KeePassDX.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+package com.kunzisoft.keepass.database.keeshare
+
+import android.util.Base64
+import com.kunzisoft.keepass.database.element.CustomData
+import org.xmlpull.v1.XmlPullParser
+import org.xmlpull.v1.XmlPullParserFactory
+import org.xmlpull.v1.XmlSerializer
+import java.io.StringReader
+import java.io.StringWriter
+import java.nio.ByteBuffer
+import java.util.UUID
+
+data class KeeShareReference(
+    val type: Int = INACTIVE,
+    val uuid: UUID = UUID(0, 0),
+    val path: String = "",
+    val password: String = "",
+    val keepGroups: Boolean = false
+) {
+
+    val isImporting: Boolean get() = type and IMPORT_FROM != 0 && path.isNotEmpty()
+
+    val isExporting: Boolean get() = type and EXPORT_TO != 0 && path.isNotEmpty()
+
+    val isValid: Boolean get() = type != INACTIVE && path.isNotEmpty()
+
+    fun serialize(): String {
+        val writer = StringWriter()
+        val serializer = XmlPullParserFactory.newInstance().newSerializer()
+        serializer.setOutput(writer)
+        serializer.startDocument("UTF-8", null)
+        serializer.startTag(null, TAG_ROOT)
+
+        serializer.startTag(null, TAG_TYPE)
+        if (type and IMPORT_FROM != 0) serializer.emptyTag(TAG_IMPORT)
+        if (type and EXPORT_TO != 0) serializer.emptyTag(TAG_EXPORT)
+        serializer.endTag(null, TAG_TYPE)
+
+        serializer.textElement(TAG_GROUP, uuidToBase64(uuid))
+        serializer.textElement(TAG_PATH, Base64.encodeToString(path.toByteArray(), Base64.NO_WRAP))
+        serializer.textElement(TAG_PASSWORD, Base64.encodeToString(password.toByteArray(), Base64.NO_WRAP))
+        serializer.textElement(TAG_KEEP_GROUPS, if (keepGroups) "True" else "False")
+
+        serializer.endTag(null, TAG_ROOT)
+        serializer.endDocument()
+        return Base64.encodeToString(writer.toString().toByteArray(), Base64.NO_WRAP)
+    }
+
+    companion object {
+        const val CUSTOM_DATA_KEY = "KeeShare/Reference"
+
+        const val INACTIVE = 0
+        const val IMPORT_FROM = 1
+        const val EXPORT_TO = 2
+        const val SYNCHRONIZE = IMPORT_FROM or EXPORT_TO
+
+        private const val TAG_ROOT = "KeeShare"
+        private const val TAG_TYPE = "Type"
+        private const val TAG_IMPORT = "Import"
+        private const val TAG_EXPORT = "Export"
+        private const val TAG_GROUP = "Group"
+        private const val TAG_PATH = "Path"
+        private const val TAG_PASSWORD = "Password"
+        private const val TAG_KEEP_GROUPS = "KeepGroups"
+
+        fun fromCustomData(customData: CustomData): KeeShareReference? {
+            val value = customData.get(CUSTOM_DATA_KEY)?.value ?: return null
+            return deserialize(value)
+        }
+
+        fun deserialize(base64Xml: String): KeeShareReference? {
+            val xml = try {
+                String(Base64.decode(base64Xml, Base64.DEFAULT), Charsets.UTF_8)
+            } catch (_: Exception) {
+                base64Xml
+            }
+            return try {
+                parseXml(xml)
+            } catch (_: Exception) {
+                null
+            }
+        }
+
+        private fun parseXml(xml: String): KeeShareReference? {
+            val factory = XmlPullParserFactory.newInstance()
+            val parser = factory.newPullParser()
+            parser.setInput(StringReader(xml))
+
+            var typeFlags = 0
+            var uuid = UUID(0, 0)
+            var path = ""
+            var password = ""
+            var keepGroups = false
+            var insideType = false
+            var currentTag = ""
+
+            var eventType = parser.eventType
+            while (eventType != XmlPullParser.END_DOCUMENT) {
+                when (eventType) {
+                    XmlPullParser.START_TAG -> {
+                        val name = parser.name
+                        if (name == TAG_TYPE) {
+                            insideType = true
+                        } else if (insideType) {
+                            when (name) {
+                                TAG_IMPORT -> typeFlags = typeFlags or IMPORT_FROM
+                                TAG_EXPORT -> typeFlags = typeFlags or EXPORT_TO
+                            }
+                        } else {
+                            currentTag = name
+                        }
+                    }
+                    XmlPullParser.TEXT -> {
+                        val text = parser.text?.trim() ?: ""
+                        if (text.isNotEmpty()) {
+                            if (insideType) {
+                                text.toIntOrNull()?.let { typeFlags = it }
+                            } else when (currentTag) {
+                                TAG_GROUP -> uuidFromBase64(text)?.let { uuid = it }
+                                TAG_PATH -> path = decodeBase64OrPlain(text)
+                                TAG_PASSWORD -> password = decodeBase64OrPlain(text)
+                                TAG_KEEP_GROUPS -> keepGroups = text.equals("True", ignoreCase = true)
+                            }
+                        }
+                    }
+                    XmlPullParser.END_TAG -> {
+                        if (parser.name == TAG_TYPE) insideType = false
+                        currentTag = ""
+                    }
+                }
+                eventType = parser.next()
+            }
+
+            if (typeFlags == INACTIVE && path.isEmpty()) return null
+            return KeeShareReference(typeFlags, uuid, path, password, keepGroups)
+        }
+
+        private fun decodeBase64OrPlain(text: String): String {
+            return try {
+                String(Base64.decode(text, Base64.DEFAULT), Charsets.UTF_8)
+            } catch (_: Exception) {
+                text
+            }
+        }
+
+        private fun uuidFromBase64(base64: String): UUID? {
+            return try {
+                val bytes = Base64.decode(base64, Base64.DEFAULT)
+                if (bytes.size != 16) return null
+                val buf = ByteBuffer.wrap(bytes)
+                UUID(buf.long, buf.long)
+            } catch (_: Exception) {
+                try { UUID.fromString(base64) } catch (_: Exception) { null }
+            }
+        }
+
+        private fun uuidToBase64(uuid: UUID): String {
+            val buf = ByteBuffer.allocate(16)
+            buf.putLong(uuid.mostSignificantBits)
+            buf.putLong(uuid.leastSignificantBits)
+            return Base64.encodeToString(buf.array(), Base64.NO_WRAP)
+        }
+
+        private fun XmlSerializer.emptyTag(name: String) {
+            startTag(null, name)
+            endTag(null, name)
+        }
+
+        private fun XmlSerializer.textElement(name: String, text: String) {
+            startTag(null, name)
+            this.text(text)
+            endTag(null, name)
+        }
+    }
+}

--- a/database/src/main/java/com/kunzisoft/keepass/database/merge/DatabaseKDBXMerger.kt
+++ b/database/src/main/java/com/kunzisoft/keepass/database/merge/DatabaseKDBXMerger.kt
@@ -44,6 +44,12 @@ class DatabaseKDBXMerger(private var database: DatabaseKDBX) {
     var isRAMSufficient: (memoryWanted: Long) -> Boolean = {true}
 
     /**
+     * Optional target group for scoped merge. When set, the source root
+     * is remapped to this group so entries land in the right place.
+     */
+    var targetGroup: GroupKDBX? = null
+
+    /**
      * Merge a KDB database in a KDBX database, by default all data are copied from the KDB
      */
     fun merge(databaseToMerge: DatabaseKDB) {
@@ -239,9 +245,11 @@ class DatabaseKDBXMerger(private var database: DatabaseKDBX) {
             throw IOException("Database is not open")
         }
 
-        // UUID of the root group to merge is unknown
-        if (database.getGroupById(rootGroupIdToMerge) == null) {
-            // Change it to copy children database root
+        if (targetGroup != null) {
+            databaseToMerge.removeGroupIndex(rootGroupToMerge)
+            rootGroupToMerge.nodeId = targetGroup!!.nodeId
+            databaseToMerge.addGroupIndex(rootGroupToMerge)
+        } else if (database.getGroupById(rootGroupIdToMerge) == null) {
             databaseToMerge.removeGroupIndex(rootGroupToMerge)
             rootGroupToMerge.nodeId = rootGroupId
             databaseToMerge.addGroupIndex(rootGroupToMerge)

--- a/database/src/test/kotlin/com/kunzisoft/keepass/database/keeshare/KeeShareReferenceTest.kt
+++ b/database/src/test/kotlin/com/kunzisoft/keepass/database/keeshare/KeeShareReferenceTest.kt
@@ -1,0 +1,165 @@
+/*
+ * Copyright 2026 Jeremy Jamet / Kunzisoft.
+ *
+ * This file is part of KeePassDX.
+ *
+ *  KeePassDX is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  KeePassDX is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with KeePassDX.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+package com.kunzisoft.keepass.database.keeshare
+
+import android.util.Base64
+import com.kunzisoft.keepass.database.element.CustomData
+import com.kunzisoft.keepass.database.element.CustomDataItem
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+
+@RunWith(RobolectricTestRunner::class)
+@Config(sdk = [34])
+class KeeShareReferenceTest {
+
+    @Test
+    fun parseImportOnlyReference() {
+        val xml = """
+            <?xml version="1.0" encoding="UTF-8"?>
+            <KeeShare>
+                <Type><Import/></Type>
+                <Group>AAAAAAAAAAAAAAAAAAAAAA==</Group>
+                <Path>${Base64.encodeToString("/shared/passwords.kdbx".toByteArray(), Base64.NO_WRAP)}</Path>
+                <Password>${Base64.encodeToString("secret".toByteArray(), Base64.NO_WRAP)}</Password>
+                <KeepGroups>False</KeepGroups>
+            </KeeShare>
+        """.trimIndent()
+        val encoded = Base64.encodeToString(xml.toByteArray(), Base64.NO_WRAP)
+
+        val ref = KeeShareReference.deserialize(encoded)
+        assertNotNull(ref)
+        assertEquals(KeeShareReference.IMPORT_FROM, ref!!.type)
+        assertTrue(ref.isImporting)
+        assertFalse(ref.isExporting)
+        assertEquals("/shared/passwords.kdbx", ref.path)
+        assertEquals("secret", ref.password)
+        assertFalse(ref.keepGroups)
+    }
+
+    @Test
+    fun parseSynchronizeReference() {
+        val xml = """
+            <?xml version="1.0" encoding="UTF-8"?>
+            <KeeShare>
+                <Type><Import/><Export/></Type>
+                <Group>AAAAAAAAAAAAAAAAAAAAAA==</Group>
+                <Path>${Base64.encodeToString("/sync/db.kdbx".toByteArray(), Base64.NO_WRAP)}</Path>
+                <Password></Password>
+                <KeepGroups>True</KeepGroups>
+            </KeeShare>
+        """.trimIndent()
+        val encoded = Base64.encodeToString(xml.toByteArray(), Base64.NO_WRAP)
+
+        val ref = KeeShareReference.deserialize(encoded)
+        assertNotNull(ref)
+        assertEquals(KeeShareReference.SYNCHRONIZE, ref!!.type)
+        assertTrue(ref.isImporting)
+        assertTrue(ref.isExporting)
+        assertTrue(ref.keepGroups)
+    }
+
+    @Test
+    fun parseLegacyIntegerType() {
+        val xml = """
+            <?xml version="1.0" encoding="UTF-8"?>
+            <KeeShare>
+                <Type>3</Type>
+                <Group>AAAAAAAAAAAAAAAAAAAAAA==</Group>
+                <Path>${Base64.encodeToString("/path".toByteArray(), Base64.NO_WRAP)}</Path>
+                <Password></Password>
+            </KeeShare>
+        """.trimIndent()
+        val encoded = Base64.encodeToString(xml.toByteArray(), Base64.NO_WRAP)
+
+        val ref = KeeShareReference.deserialize(encoded)
+        assertNotNull(ref)
+        assertEquals(KeeShareReference.SYNCHRONIZE, ref!!.type)
+    }
+
+    @Test
+    fun returnNullForInactiveEmptyPath() {
+        val xml = """
+            <?xml version="1.0" encoding="UTF-8"?>
+            <KeeShare>
+                <Type>0</Type>
+                <Group>AAAAAAAAAAAAAAAAAAAAAA==</Group>
+                <Path></Path>
+                <Password></Password>
+            </KeeShare>
+        """.trimIndent()
+        val encoded = Base64.encodeToString(xml.toByteArray(), Base64.NO_WRAP)
+
+        assertNull(KeeShareReference.deserialize(encoded))
+    }
+
+    @Test
+    fun returnNullForGarbage() {
+        assertNull(KeeShareReference.deserialize("not-valid-at-all!!!"))
+    }
+
+    @Test
+    fun fromCustomDataFindsReference() {
+        val xml = """
+            <?xml version="1.0" encoding="UTF-8"?>
+            <KeeShare>
+                <Type><Import/></Type>
+                <Group>AAAAAAAAAAAAAAAAAAAAAA==</Group>
+                <Path>${Base64.encodeToString("/test".toByteArray(), Base64.NO_WRAP)}</Path>
+                <Password></Password>
+            </KeeShare>
+        """.trimIndent()
+        val encoded = Base64.encodeToString(xml.toByteArray(), Base64.NO_WRAP)
+
+        val customData = CustomData()
+        customData.put(CustomDataItem(KeeShareReference.CUSTOM_DATA_KEY, encoded))
+        val ref = KeeShareReference.fromCustomData(customData)
+        assertNotNull(ref)
+        assertEquals("/test", ref!!.path)
+    }
+
+    @Test
+    fun fromCustomDataReturnsNullWhenMissing() {
+        assertNull(KeeShareReference.fromCustomData(CustomData()))
+    }
+
+    @Test
+    fun roundTripSerializeDeserialize() {
+        val original = KeeShareReference(
+            type = KeeShareReference.SYNCHRONIZE,
+            path = "/shared/db.kdbx",
+            password = "mypass",
+            keepGroups = true
+        )
+        val serialized = original.serialize()
+        val parsed = KeeShareReference.deserialize(serialized)
+        assertNotNull(parsed)
+        assertEquals(original.type, parsed!!.type)
+        assertEquals(original.path, parsed.path)
+        assertEquals(original.password, parsed.password)
+        assertEquals(original.keepGroups, parsed.keepGroups)
+    }
+}


### PR DESCRIPTION
Read-only KeeShare import, compatible with KeePassXC's standard protocol.

### What this does

Detects KeeShare references in group CustomData (as set by KeePassXC), lets the user link a container .kdbx file via SAF, and merges entries into the shared group — silently, in the background, on database open and on ContentObserver changes. Same merge mechanism as the existing "Merge database" action, just scoped to the target group.

### Changes

- **Scoped merge** on `DatabaseKDBXMerger` — `targetGroup` remaps the source root so entries land in the right group
- **`ACTION_KEESHARE_MERGE_TASK`** — silent service action, no notification/reload/broadcast, just `rebuildList()` on completion
- **KeeShareReference parser** — reads `KeeShare/Reference` from group CustomData, compatible with KeePassXC format
- **UI indicator** — share icon on shared groups, red when no container linked, tap to select via SAF
- **Merge-on-open** — imports from configured containers when the database is opened
- **ContentObserver** — watches container URIs for changes (works with Syncthing and other SAF-aware sync tools)

### On multiple database support

I don't see the need for simultaneous database handling for KeeShare. Containers are opened transiently during merge (load → merge → close), same as KeePassXC's `ShareImport::containerInto()`. Multiple shared groups are processed sequentially through the service task queue. The existing single-database should handle this correctly.


### Known limitations

- No KeeShare section in group edit dialog yet (relink/unlink only via icon tap)
- Keeshare needs to be initially set up in KeepassXC
- No merge status indicator
- No Write/export

### Manual Testing
I've run it several times with some sample data in emulator and it seemed to update the entries correctly. However, I didn't manage to manually trigger an update event via adb, to trigger the ContentObserver.

Ref: #2438, #2434