### PR TITLE
Add KeeShare write/export to container file

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -173,5 +173,10 @@ dependencies {
     implementation project(path: ':icon-pack')
 
     // Tests
-    androidTestImplementation "androidx.test:runner:$android_test_version"
+    androidTestImplementation "androidx.test:runner:1.5.2"
+    androidTestImplementation "androidx.test:rules:1.5.0"
+    androidTestImplementation "androidx.test.ext:junit:1.1.5"
+    androidTestImplementation "androidx.test.espresso:espresso-core:3.5.1"
+    testImplementation "junit:junit:4.13.2"
+    testImplementation "org.robolectric:robolectric:4.11.1"
 }

--- a/app/src/androidTest/java/com/kunzisoft/keepass/keeshare/KeeShareExportTest.kt
+++ b/app/src/androidTest/java/com/kunzisoft/keepass/keeshare/KeeShareExportTest.kt
@@ -1,0 +1,189 @@
+/*
+ * Copyright 2026 Jeremy Jamet / Kunzisoft.
+ *
+ * This file is part of KeePassDX.
+ *
+ *  KeePassDX is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  KeePassDX is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with KeePassDX.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+package com.kunzisoft.keepass.keeshare
+
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import androidx.test.platform.app.InstrumentationRegistry
+import com.kunzisoft.keepass.database.element.Database
+import com.kunzisoft.keepass.database.element.Entry
+import com.kunzisoft.keepass.database.element.MasterCredential
+import com.kunzisoft.keepass.database.element.node.NodeHandler
+import com.kunzisoft.keepass.database.keeshare.KeeShareExport
+import com.kunzisoft.keepass.database.keeshare.KeeShareReference
+import com.kunzisoft.keepass.hardware.HardwareKey
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import java.io.File
+
+@RunWith(AndroidJUnit4::class)
+class KeeShareExportTest {
+
+    private lateinit var db: Database
+    private val password = "testpass"
+    private val noOpChallengeResponse: (HardwareKey, ByteArray?) -> ByteArray = { _, _ -> ByteArray(0) }
+    private lateinit var cacheDir: File
+    private lateinit var containerFile: File
+
+    @Before
+    fun setUp() {
+        val context = InstrumentationRegistry.getInstrumentation().targetContext
+        cacheDir = File(context.cacheDir, "keeshare_export_test").apply { mkdirs() }
+        containerFile = File(cacheDir, "exported_container.kdbx")
+        db = TestDatabaseBuilder.createMainDatabase(cacheDir, password)
+    }
+
+    private fun collectEntryTitles(group: com.kunzisoft.keepass.database.element.Group?): List<String> {
+        val titles = mutableListOf<String>()
+        group?.doForEachChild(
+            object : NodeHandler<Entry>() {
+                override fun operate(node: Entry): Boolean {
+                    titles.add(node.title)
+                    return true
+                }
+            },
+            null
+        )
+        return titles
+    }
+
+    @Test
+    fun exportCreatesContainerFile() {
+        val shared = db.getAllGroupsWithoutRoot().find { it.title == "SharedGroup" }
+        assertNotNull(shared)
+        val ref = KeeShareReference.fromCustomData(shared!!.customData)
+        assertNotNull(ref)
+
+        val exportCacheFile = File(cacheDir, "export_cache.tmp")
+
+        KeeShareExport.exportSharedGroup(
+            db,
+            shared,
+            ref!!,
+            exportCacheFile,
+            { containerFile.outputStream() },
+            noOpChallengeResponse
+        )
+
+        assertTrue("Container file should exist", containerFile.exists())
+        assertTrue("Container file should not be empty", containerFile.length() > 0)
+    }
+
+    @Test
+    fun exportedContainerCanBeImported() {
+        val shared = db.getAllGroupsWithoutRoot().find { it.title == "SharedGroup" }!!
+        val ref = KeeShareReference.fromCustomData(shared.customData)!!
+        val exportCacheFile = File(cacheDir, "export_cache.tmp")
+
+        KeeShareExport.exportSharedGroup(
+            db, shared, ref, exportCacheFile,
+            { containerFile.outputStream() },
+            noOpChallengeResponse
+        )
+
+        val importDb = Database()
+        importDb.createData("ImportTest", "Root", null)
+
+        importDb.mergeData(
+            containerFile.inputStream(),
+            MasterCredential(CharArray(0)),
+            noOpChallengeResponse,
+            isRAMSufficient = { true },
+            progressTaskUpdater = null
+        )
+
+        val importedEntries = collectEntryTitles(importDb.rootGroup)
+        val sharedEntries = collectEntryTitles(shared)
+
+        for (entry in sharedEntries) {
+            assertTrue(
+                "Exported entry '$entry' should be in imported container",
+                importedEntries.contains(entry)
+            )
+        }
+    }
+
+    @Test
+    fun exportDoesNotIncludeNormalGroupEntries() {
+        val shared = db.getAllGroupsWithoutRoot().find { it.title == "SharedGroup" }!!
+        val ref = KeeShareReference.fromCustomData(shared.customData)!!
+        val exportCacheFile = File(cacheDir, "export_cache.tmp")
+
+        KeeShareExport.exportSharedGroup(
+            db, shared, ref, exportCacheFile,
+            { containerFile.outputStream() },
+            noOpChallengeResponse
+        )
+
+        val importDb = Database()
+        importDb.createData("ImportTest", "Root", null)
+        importDb.mergeData(
+            containerFile.inputStream(),
+            MasterCredential(CharArray(0)),
+            noOpChallengeResponse,
+            isRAMSufficient = { true },
+            progressTaskUpdater = null
+        )
+
+        val importedEntries = collectEntryTitles(importDb.rootGroup)
+        val normalEntries = collectEntryTitles(
+            db.getAllGroupsWithoutRoot().find { it.title == "NormalGroup" }
+        )
+
+        for (entry in normalEntries) {
+            assertTrue(
+                "NormalGroup entry '$entry' should NOT be in container",
+                !importedEntries.contains(entry)
+            )
+        }
+    }
+
+    @Test
+    fun roundTripExportImportPreservesEntries() {
+        val shared = db.getAllGroupsWithoutRoot().find { it.title == "SharedGroup" }!!
+        val ref = KeeShareReference.fromCustomData(shared.customData)!!
+        val exportCacheFile = File(cacheDir, "export_cache.tmp")
+        val allEntriesBefore = collectEntryTitles(db.rootGroup)
+
+        KeeShareExport.exportSharedGroup(
+            db, shared, ref, exportCacheFile,
+            { containerFile.outputStream() },
+            noOpChallengeResponse
+        )
+
+        db.mergeData(
+            containerFile.inputStream(),
+            MasterCredential(CharArray(0)),
+            noOpChallengeResponse,
+            isRAMSufficient = { true },
+            progressTaskUpdater = null
+        )
+
+        val allEntriesAfter = collectEntryTitles(db.rootGroup)
+        for (entry in allEntriesBefore) {
+            assertTrue(
+                "Entry '$entry' should survive export+import round-trip",
+                allEntriesAfter.contains(entry)
+            )
+        }
+    }
+}

--- a/app/src/androidTest/java/com/kunzisoft/keepass/keeshare/KeeShareIntegrationTest.kt
+++ b/app/src/androidTest/java/com/kunzisoft/keepass/keeshare/KeeShareIntegrationTest.kt
@@ -1,0 +1,170 @@
+/*
+ * Copyright 2026 Jeremy Jamet / Kunzisoft.
+ *
+ * This file is part of KeePassDX.
+ *
+ *  KeePassDX is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  KeePassDX is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with KeePassDX.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+package com.kunzisoft.keepass.keeshare
+
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import androidx.test.platform.app.InstrumentationRegistry
+import com.kunzisoft.keepass.database.element.Database
+import com.kunzisoft.keepass.database.element.Entry
+import com.kunzisoft.keepass.database.element.Group
+import com.kunzisoft.keepass.database.element.MasterCredential
+import com.kunzisoft.keepass.database.element.node.NodeHandler
+import com.kunzisoft.keepass.database.keeshare.KeeShareReference
+import com.kunzisoft.keepass.hardware.HardwareKey
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import java.io.File
+
+@RunWith(AndroidJUnit4::class)
+class KeeShareIntegrationTest {
+
+    private lateinit var db: Database
+    private lateinit var cacheDir: File
+    private val password = "testpass"
+    private val noOpChallengeResponse: (HardwareKey, ByteArray?) -> ByteArray = { _, _ -> ByteArray(0) }
+
+    @Before
+    fun setUp() {
+        cacheDir = File(
+            InstrumentationRegistry.getInstrumentation().targetContext.cacheDir,
+            "keeshare_test"
+        ).apply { mkdirs() }
+        db = TestDatabaseBuilder.createMainDatabase(cacheDir, password)
+    }
+
+    private fun collectEntryTitles(group: Group?): List<String> {
+        val titles = mutableListOf<String>()
+        group?.doForEachChild(
+            object : NodeHandler<Entry>() {
+                override fun operate(node: Entry): Boolean {
+                    titles.add(node.title)
+                    return true
+                }
+            },
+            null
+        )
+        return titles
+    }
+
+    @Test
+    fun databaseLoadsWithGroups() {
+        assertTrue(db.loaded)
+        assertNotNull(db.rootGroup)
+        val names = db.getAllGroupsWithoutRoot().map { it.title }
+        assertTrue(names.contains("SharedGroup"))
+        assertTrue(names.contains("NormalGroup"))
+    }
+
+    @Test
+    fun sharedGroupHasKeeShareReference() {
+        val shared = db.getAllGroupsWithoutRoot().find { it.title == "SharedGroup" }
+        assertNotNull(shared)
+        val ref = KeeShareReference.fromCustomData(shared!!.customData)
+        assertNotNull(ref)
+        assertTrue(ref!!.isImporting)
+        assertTrue(ref.isExporting)
+    }
+
+    @Test
+    fun normalGroupHasNoKeeShareReference() {
+        val normal = db.getAllGroupsWithoutRoot().find { it.title == "NormalGroup" }
+        assertNotNull(normal)
+        assertTrue(KeeShareReference.fromCustomData(normal!!.customData) == null)
+    }
+
+    @Test
+    fun sharedGroupDetectedByForEachGroupWithCustomData() {
+        val found = mutableListOf<String>()
+        db.forEachGroupWithCustomData { found.add(it.title) }
+        assertTrue(found.contains("SharedGroup"))
+        assertTrue(!found.contains("NormalGroup"))
+    }
+
+    @Test
+    fun mergeContainerAddsNewEntry() {
+        val containerFile = TestDatabaseBuilder.saveToFile(
+            TestDatabaseBuilder.createContainer(cacheDir, password),
+            cacheDir, password, "container.kdbx"
+        )
+
+        db.mergeData(
+            containerFile.inputStream(),
+            MasterCredential(password.toCharArray()),
+            noOpChallengeResponse,
+            isRAMSufficient = { true },
+            progressTaskUpdater = null
+        )
+
+        val allEntries = collectEntryTitles(db.rootGroup)
+        assertTrue("DesktopNewEntry should appear after merge", allEntries.contains("DesktopNewEntry"))
+        containerFile.delete()
+    }
+
+    @Test
+    fun mergeContainerPreservesExistingEntries() {
+        val beforeEntries = collectEntryTitles(db.rootGroup)
+        val containerFile = TestDatabaseBuilder.saveToFile(
+            TestDatabaseBuilder.createContainer(cacheDir, password),
+            cacheDir, password, "container.kdbx"
+        )
+
+        db.mergeData(
+            containerFile.inputStream(),
+            MasterCredential(password.toCharArray()),
+            noOpChallengeResponse,
+            isRAMSufficient = { true },
+            progressTaskUpdater = null
+        )
+
+        val afterEntries = collectEntryTitles(db.rootGroup)
+        for (entry in beforeEntries) {
+            assertTrue("$entry should still exist after merge", afterEntries.contains(entry))
+        }
+        containerFile.delete()
+    }
+
+    @Test
+    fun mergeContainerDoesNotDuplicateNormalGroupEntries() {
+        val normalBefore = collectEntryTitles(
+            db.getAllGroupsWithoutRoot().find { it.title == "NormalGroup" }
+        )
+        val containerFile = TestDatabaseBuilder.saveToFile(
+            TestDatabaseBuilder.createContainer(cacheDir, password),
+            cacheDir, password, "container.kdbx"
+        )
+
+        db.mergeData(
+            containerFile.inputStream(),
+            MasterCredential(password.toCharArray()),
+            noOpChallengeResponse,
+            isRAMSufficient = { true },
+            progressTaskUpdater = null
+        )
+
+        val normalAfter = collectEntryTitles(
+            db.getAllGroupsWithoutRoot().find { it.title == "NormalGroup" }
+        )
+        assertTrue("NormalGroup should be unchanged", normalBefore == normalAfter)
+        containerFile.delete()
+    }
+}

--- a/app/src/androidTest/java/com/kunzisoft/keepass/keeshare/TestDatabaseBuilder.kt
+++ b/app/src/androidTest/java/com/kunzisoft/keepass/keeshare/TestDatabaseBuilder.kt
@@ -1,0 +1,105 @@
+/*
+ * Copyright 2026 Jeremy Jamet / Kunzisoft.
+ *
+ * This file is part of KeePassDX.
+ *
+ *  KeePassDX is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  KeePassDX is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with KeePassDX.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+package com.kunzisoft.keepass.keeshare
+
+import com.kunzisoft.keepass.database.element.CustomData
+import com.kunzisoft.keepass.database.element.CustomDataItem
+import com.kunzisoft.keepass.database.element.Database
+import com.kunzisoft.keepass.database.element.Entry
+import com.kunzisoft.keepass.database.element.Group
+import com.kunzisoft.keepass.database.element.MasterCredential
+import com.kunzisoft.keepass.database.keeshare.KeeShareReference
+import com.kunzisoft.keepass.hardware.HardwareKey
+import java.io.File
+
+/** Builds test .kdbx databases programmatically without shipping binary assets. */
+object TestDatabaseBuilder {
+
+    private val noOpChallengeResponse: (HardwareKey, ByteArray?) -> ByteArray = { _, _ -> ByteArray(0) }
+
+    private fun addEntry(db: Database, parent: Group, title: String, user: String, pass: String, url: String = "") {
+        val entry: Entry = db.createEntry() ?: return
+        entry.title = title
+        entry.username = user
+        entry.password = pass.toCharArray()
+        if (url.isNotEmpty()) entry.url = url
+        db.addEntryTo(entry, parent)
+    }
+
+    /** Create a main database with a shared group (KeeShare ref) and a normal group. */
+    fun createMainDatabase(cacheDir: File, password: String): Database {
+        val db = Database()
+        db.createData("TestDB", "Root", null)
+        val root = db.rootGroup!!
+
+        val shared: Group = db.createGroup()!!
+        shared.title = "SharedGroup"
+        db.addGroupTo(shared, root)
+
+        val ref = KeeShareReference(type = KeeShareReference.SYNCHRONIZE, path = "/Sync/shared.kdbx")
+        shared.customData = CustomData().apply {
+            put(CustomDataItem(KeeShareReference.CUSTOM_DATA_KEY, ref.serialize()))
+        }
+
+        addEntry(db, shared, "TestEntry", "testuser", "testpass123", "https://example.com")
+        addEntry(db, shared, "SharedEntry2", "shareduser2", "sharedpass2")
+
+        val normal: Group = db.createGroup()!!
+        normal.title = "NormalGroup"
+        db.addGroupTo(normal, root)
+
+        addEntry(db, normal, "NormalEntry1", "user1", "pass1")
+        addEntry(db, normal, "NormalEntry2", "user2", "pass2")
+
+        return saveAndReload(db, cacheDir, password)
+    }
+
+    /** Create a container simulating a KeePassXC export with an extra entry. */
+    fun createContainer(cacheDir: File, password: String): Database {
+        val db = Database()
+        db.createData("KeeShare", "Root", null)
+        val root = db.rootGroup!!
+
+        addEntry(db, root, "TestEntry", "testuser", "testpass123")
+        addEntry(db, root, "DesktopNewEntry", "desktop_user", "desktop_pass", "https://added-on-desktop.com")
+
+        return saveAndReload(db, cacheDir, password)
+    }
+
+    /** Save a database to a file. */
+    fun saveToFile(db: Database, cacheDir: File, password: String, filename: String): File {
+        val outFile = File(cacheDir, filename)
+        val tmpFile = File(cacheDir, "$filename.tmp")
+        db.saveData(tmpFile, { outFile.outputStream() }, true,
+            MasterCredential(password.toCharArray()), noOpChallengeResponse)
+        return outFile
+    }
+
+    private fun saveAndReload(db: Database, cacheDir: File, password: String): Database {
+        val file = saveToFile(db, cacheDir, password, "temp_${System.nanoTime()}.kdbx")
+        val reloaded = Database()
+        reloaded.loadData(file.inputStream(), MasterCredential(password.toCharArray()),
+            noOpChallengeResponse, readOnly = false, allowUserVerification = false,
+            cacheDirectory = cacheDir, isRAMSufficient = { true },
+            fixDuplicateUUID = false, progressTaskUpdater = null)
+        file.delete()
+        return reloaded
+    }
+}

--- a/app/src/main/java/com/kunzisoft/keepass/activities/GroupActivity.kt
+++ b/app/src/main/java/com/kunzisoft/keepass/activities/GroupActivity.kt
@@ -108,6 +108,7 @@ import com.kunzisoft.keepass.timeout.TimeoutHelper
 import com.kunzisoft.keepass.utils.BACK_PREVIOUS_KEYBOARD_ACTION
 import com.kunzisoft.keepass.utils.KeyboardUtil.showKeyboard
 import com.kunzisoft.keepass.utils.TimeUtil.datePickerToDataDate
+import com.kunzisoft.keepass.keeshare.KeeShareObserver
 import com.kunzisoft.keepass.utils.UriUtil.openUrl
 import com.kunzisoft.keepass.utils.UriUtil.takeUriPermission
 import com.kunzisoft.keepass.utils.getParcelableCompat
@@ -185,6 +186,7 @@ class GroupActivity : DatabaseLockActivity(),
     private var mExternalFileHelper: ExternalFileHelper? = null
     private var mPendingKeeShareGroupUuid: String? = null
     private var mKeeShareFileHelper: ExternalFileHelper? = null
+    private var mKeeShareObserver: KeeShareObserver? = null
 
     // Manage group
     private var mSearchState: SearchState? = null
@@ -687,6 +689,7 @@ class GroupActivity : DatabaseLockActivity(),
 
     override fun onDatabaseRetrieved(database: ContextualDatabase) {
         super.onDatabaseRetrieved(database)
+        startKeeShareObservers(database)
 
         mBreadcrumbAdapter = BreadcrumbAdapter(this, database).apply {
             // Open group on breadcrumb click
@@ -932,6 +935,20 @@ class GroupActivity : DatabaseLockActivity(),
     override fun onScrolled(dy: Int) {
         if (actionNodeMode == null)
             addNodeButtonView?.hideOrShowButtonOnScrollListener(dy)
+    }
+
+    private fun startKeeShareObservers(database: ContextualDatabase) {
+        mKeeShareObserver?.stopAll(contentResolver)
+        if (!database.supportsKeeShare) return
+        mKeeShareObserver = KeeShareObserver {
+            mDatabaseViewModel.mergeDatabase(false)
+        }
+        database.forEachGroupWithCustomData { group ->
+            val uriString = PreferencesUtil.getKeeShareContainerUri(this, group.nodeId.toString())
+            if (uriString != null) {
+                mKeeShareObserver?.observe(contentResolver, Uri.parse(uriString))
+            }
+        }
     }
 
     override fun onKeeShareIconClick(database: ContextualDatabase, group: Group) {
@@ -1288,6 +1305,7 @@ class GroupActivity : DatabaseLockActivity(),
 
     override fun onPause() {
         super.onPause()
+        mKeeShareObserver?.stopAll(contentResolver)
 
         finishNodeAction()
         searchView?.setOnQueryTextListener(null)

--- a/app/src/main/java/com/kunzisoft/keepass/activities/GroupActivity.kt
+++ b/app/src/main/java/com/kunzisoft/keepass/activities/GroupActivity.kt
@@ -109,6 +109,7 @@ import com.kunzisoft.keepass.utils.BACK_PREVIOUS_KEYBOARD_ACTION
 import com.kunzisoft.keepass.utils.KeyboardUtil.showKeyboard
 import com.kunzisoft.keepass.utils.TimeUtil.datePickerToDataDate
 import com.kunzisoft.keepass.utils.UriUtil.openUrl
+import com.kunzisoft.keepass.utils.UriUtil.takeUriPermission
 import com.kunzisoft.keepass.utils.getParcelableCompat
 import com.kunzisoft.keepass.utils.getParcelableExtraCompat
 import com.kunzisoft.keepass.utils.getParcelableList
@@ -140,6 +141,7 @@ class GroupActivity : DatabaseLockActivity(),
         GroupFragment.NodesActionMenuListener,
         GroupFragment.OnScrollListener,
         GroupFragment.GroupRefreshedListener,
+        GroupFragment.KeeShareIconClickListener,
         SortDialogFragment.SortSelectionListener {
 
     // Views
@@ -181,6 +183,8 @@ class GroupActivity : DatabaseLockActivity(),
 
     // Manage merge
     private var mExternalFileHelper: ExternalFileHelper? = null
+    private var mPendingKeeShareGroupUuid: String? = null
+    private var mKeeShareFileHelper: ExternalFileHelper? = null
 
     // Manage group
     private var mSearchState: SearchState? = null
@@ -352,6 +356,17 @@ class GroupActivity : DatabaseLockActivity(),
         mExternalFileHelper?.buildCreateDocument("application/x-keepass") { uri ->
             uri?.let {
                 saveDatabaseTo(it)
+            }
+        }
+
+        mKeeShareFileHelper = ExternalFileHelper(this)
+        mKeeShareFileHelper?.buildOpenDocument { uri ->
+            uri?.let { selectedUri ->
+                mPendingKeeShareGroupUuid?.let { groupUuid ->
+                    contentResolver?.takeUriPermission(selectedUri)
+                    PreferencesUtil.setKeeShareContainerUri(this, groupUuid, selectedUri.toString())
+                    mPendingKeeShareGroupUuid = null
+                }
             }
         }
 
@@ -917,6 +932,11 @@ class GroupActivity : DatabaseLockActivity(),
     override fun onScrolled(dy: Int) {
         if (actionNodeMode == null)
             addNodeButtonView?.hideOrShowButtonOnScrollListener(dy)
+    }
+
+    override fun onKeeShareIconClick(database: ContextualDatabase, group: Group) {
+        mPendingKeeShareGroupUuid = group.nodeId.toString()
+        mKeeShareFileHelper?.openDocument()
     }
 
     override fun onNodeClick(

--- a/app/src/main/java/com/kunzisoft/keepass/activities/fragments/GroupFragment.kt
+++ b/app/src/main/java/com/kunzisoft/keepass/activities/fragments/GroupFragment.kt
@@ -52,6 +52,7 @@ import com.kunzisoft.keepass.viewmodels.GroupViewModel
 class GroupFragment : DatabaseFragment(), SortDialogFragment.SortSelectionListener {
 
     private var nodeClickListener: NodeClickListener? = null
+    private var keeShareIconClickListener: KeeShareIconClickListener? = null
     private var onScrollListener: OnScrollListener? = null
     private var groupRefreshed: GroupRefreshedListener? = null
 
@@ -144,10 +145,13 @@ class GroupFragment : DatabaseFragment(), SortDialogFragment.SortSelectionListen
             throw ClassCastException(context.toString()
                     + " must implement " + GroupRefreshedListener::class.java.name)
         }
+
+        keeShareIconClickListener = context as? KeeShareIconClickListener
     }
 
     override fun onDetach() {
         nodeClickListener = null
+        keeShareIconClickListener = null
         onScrollListener = null
         groupRefreshed = null
         super.onDetach()
@@ -187,6 +191,11 @@ class GroupFragment : DatabaseFragment(), SortDialogFragment.SortSelectionListen
                             activity?.hideKeyboard()
                         }
                         return true
+                    }
+                })
+                setOnKeeShareIconClickListener(object : NodesAdapter.KeeShareIconClickCallback {
+                    override fun onKeeShareIconClick(database: ContextualDatabase, group: Group) {
+                        keeShareIconClickListener?.onKeeShareIconClick(database, group)
                     }
                 })
             }
@@ -403,6 +412,10 @@ class GroupFragment : DatabaseFragment(), SortDialogFragment.SortSelectionListen
     interface NodeClickListener {
         fun onNodeClick(database: ContextualDatabase, node: Node)
         fun onNodeSelected(database: ContextualDatabase, nodes: List<Node>): Boolean
+    }
+
+    interface KeeShareIconClickListener {
+        fun onKeeShareIconClick(database: ContextualDatabase, group: Group)
     }
 
     /**

--- a/app/src/main/java/com/kunzisoft/keepass/adapters/NodesAdapter.kt
+++ b/app/src/main/java/com/kunzisoft/keepass/adapters/NodesAdapter.kt
@@ -46,6 +46,7 @@ import com.kunzisoft.keepass.database.element.node.Node
 import com.kunzisoft.keepass.database.element.node.NodeVersionedInterface
 import com.kunzisoft.keepass.database.element.node.Type
 import com.kunzisoft.keepass.database.element.template.TemplateField
+import com.kunzisoft.keepass.database.keeshare.KeeShareReference
 import com.kunzisoft.keepass.database.helper.getLocalizedName
 import com.kunzisoft.keepass.otp.OtpElement
 import com.kunzisoft.keepass.otp.OtpType
@@ -91,6 +92,7 @@ class NodesAdapter (
 
     private var mActionNodesList = mutableListOf<Node>()
     private var mNodeClickCallback: NodeClickCallback? = null
+    private var mKeeShareIconClickCallback: KeeShareIconClickCallback? = null
     private var mClipboardHelper = ClipboardHelper(context)
 
     @ColorInt
@@ -525,6 +527,23 @@ class NodesAdapter (
             } else {
                 holder.numberChildren?.visibility = View.GONE
             }
+            holder.keeShareIcon?.apply {
+                val group = subNode as Group
+                val ref = KeeShareReference.fromCustomData(group.customData)
+                if (ref != null) {
+                    visibility = View.VISIBLE
+                    val configured = PreferencesUtil.getKeeShareContainerUri(
+                        context, group.nodeId.toString()
+                    ) != null
+                    setColorFilter(if (configured) iconColor else Color.RED)
+                    setOnClickListener {
+                        mKeeShareIconClickCallback?.onKeeShareIconClick(database, group)
+                    }
+                } else {
+                    visibility = View.GONE
+                    setOnClickListener(null)
+                }
+            }
         }
 
         // Assign image
@@ -627,12 +646,17 @@ class NodesAdapter (
         this.mNodeClickCallback = nodeClickCallback
     }
 
-    /**
-     * Callback listener to redefine to do an action when a node is click
-     */
+    fun setOnKeeShareIconClickListener(callback: KeeShareIconClickCallback?) {
+        this.mKeeShareIconClickCallback = callback
+    }
+
     interface NodeClickCallback {
         fun onNodeClick(database: ContextualDatabase, node: Node)
         fun onNodeLongClick(database: ContextualDatabase, node: Node): Boolean
+    }
+
+    interface KeeShareIconClickCallback {
+        fun onKeeShareIconClick(database: ContextualDatabase, group: Group)
     }
 
     class NodeViewHolder(itemView: View) : RecyclerView.ViewHolder(itemView) {
@@ -651,6 +675,7 @@ class NodesAdapter (
         var numberChildren: TextView? = itemView.findViewById(R.id.node_child_numbers)
         var attachmentIcon: ImageView? = itemView.findViewById(R.id.node_attachment_icon)
         var passkeyIcon: ImageView? = itemView.findViewById(R.id.node_passkey_icon)
+        var keeShareIcon: ImageView? = itemView.findViewById(R.id.node_keeshare_icon)
     }
 
     companion object {

--- a/app/src/main/java/com/kunzisoft/keepass/keeshare/KeeShareObserver.kt
+++ b/app/src/main/java/com/kunzisoft/keepass/keeshare/KeeShareObserver.kt
@@ -1,0 +1,72 @@
+/*
+ * Copyright 2026 Jeremy Jamet / Kunzisoft.
+ *
+ * This file is part of KeePassDX.
+ *
+ *  KeePassDX is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  KeePassDX is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with KeePassDX.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+package com.kunzisoft.keepass.keeshare
+
+import android.content.ContentResolver
+import android.database.ContentObserver
+import android.net.Uri
+import android.os.Handler
+import android.os.Looper
+import android.util.Log
+
+class KeeShareObserver(private val onChange: () -> Unit) {
+
+    private val observers = mutableMapOf<Uri, ContentObserver>()
+
+    fun observe(contentResolver: ContentResolver, uri: Uri) {
+        stop(contentResolver, uri)
+        val observer = object : ContentObserver(Handler(Looper.getMainLooper())) {
+            override fun onChange(selfChange: Boolean) {
+                onChange()
+            }
+        }
+        try {
+            contentResolver.registerContentObserver(uri, true, observer)
+            observers[uri] = observer
+        } catch (e: Exception) {
+            Log.e(TAG, "Failed to register ContentObserver for $uri", e)
+        }
+    }
+
+    fun stop(contentResolver: ContentResolver, uri: Uri) {
+        observers.remove(uri)?.let {
+            try {
+                contentResolver.unregisterContentObserver(it)
+            } catch (e: Exception) {
+                Log.e(TAG, "Failed to unregister ContentObserver", e)
+            }
+        }
+    }
+
+    fun stopAll(contentResolver: ContentResolver) {
+        observers.values.forEach {
+            try {
+                contentResolver.unregisterContentObserver(it)
+            } catch (e: Exception) {
+                Log.e(TAG, "Failed to unregister ContentObserver", e)
+            }
+        }
+        observers.clear()
+    }
+
+    companion object {
+        private val TAG = KeeShareObserver::class.java.name
+    }
+}

--- a/app/src/main/java/com/kunzisoft/keepass/keeshare/KeeShareUtil.kt
+++ b/app/src/main/java/com/kunzisoft/keepass/keeshare/KeeShareUtil.kt
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2026 Jeremy Jamet / Kunzisoft.
+ *
+ * This file is part of KeePassDX.
+ *
+ *  KeePassDX is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  KeePassDX is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with KeePassDX.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+package com.kunzisoft.keepass.keeshare
+
+import android.content.Context
+import android.net.Uri
+import androidx.documentfile.provider.DocumentFile
+
+object KeeShareUtil {
+
+    fun listContainerFiles(context: Context, treeUri: Uri): List<DocumentFile> {
+        val tree = DocumentFile.fromTreeUri(context, treeUri) ?: return emptyList()
+        return listContainerFiles(tree)
+    }
+
+    fun listContainerFiles(directory: DocumentFile): List<DocumentFile> {
+        if (!directory.isDirectory) return emptyList()
+        return directory.listFiles().filter {
+            it.isFile && it.name?.endsWith(".kdbx", ignoreCase = true) == true
+        }
+    }
+}

--- a/app/src/main/java/com/kunzisoft/keepass/settings/PreferencesUtil.kt
+++ b/app/src/main/java/com/kunzisoft/keepass/settings/PreferencesUtil.kt
@@ -962,4 +962,21 @@ object PreferencesUtil {
             Education.putPropertiesInEducationPreferences(context, editor, name, value)
         }
     }
+
+    private const val KEESHARE_CONTAINER_PREFIX = "keeshare_container_"
+
+    /** Store the SAF URI for a KeeShare container associated with a group UUID. */
+    fun setKeeShareContainerUri(context: Context, groupUuid: String, uri: String?) {
+        PreferenceManager.getDefaultSharedPreferences(context).edit().apply {
+            if (uri != null) putString(KEESHARE_CONTAINER_PREFIX + groupUuid, uri)
+            else remove(KEESHARE_CONTAINER_PREFIX + groupUuid)
+            apply()
+        }
+    }
+
+    /** Retrieve the SAF URI for a KeeShare container associated with a group UUID. */
+    fun getKeeShareContainerUri(context: Context, groupUuid: String): String? {
+        return PreferenceManager.getDefaultSharedPreferences(context)
+            .getString(KEESHARE_CONTAINER_PREFIX + groupUuid, null)
+    }
 }

--- a/app/src/main/res/layout/item_list_nodes_group.xml
+++ b/app/src/main/res/layout/item_list_nodes_group.xml
@@ -108,6 +108,16 @@
         </LinearLayout>
 
         <androidx.appcompat.widget.AppCompatImageView
+            android:id="@+id/node_keeshare_icon"
+            android:layout_width="16dp"
+            android:layout_height="16dp"
+            android:layout_toStartOf="@+id/node_image_identifier"
+            android:layout_toLeftOf="@+id/node_image_identifier"
+            android:layout_centerVertical="true"
+            android:src="@drawable/ic_share_white_24dp"
+            android:visibility="gone" />
+
+        <androidx.appcompat.widget.AppCompatImageView
             android:id="@+id/node_image_identifier"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"

--- a/app/src/test/kotlin/com/kunzisoft/keepass/keeshare/KeeSharePreferencesTest.kt
+++ b/app/src/test/kotlin/com/kunzisoft/keepass/keeshare/KeeSharePreferencesTest.kt
@@ -1,0 +1,75 @@
+/*
+ * Copyright 2026 Jeremy Jamet / Kunzisoft.
+ *
+ * This file is part of KeePassDX.
+ *
+ *  KeePassDX is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  KeePassDX is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with KeePassDX.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+package com.kunzisoft.keepass.keeshare
+
+import com.kunzisoft.keepass.settings.PreferencesUtil
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.RuntimeEnvironment
+import org.robolectric.annotation.Config
+
+@RunWith(RobolectricTestRunner::class)
+@Config(sdk = [34])
+class KeeSharePreferencesTest {
+
+    private val context get() = RuntimeEnvironment.getApplication()
+
+    @Test
+    fun storeAndRetrieveContainerUri() {
+        val uuid = "550e8400-e29b-41d4-a716-446655440000"
+        val uri = "content://com.android.providers.downloads.documents/tree/raw%3A%2Fsync%2Fshared.kdbx"
+        PreferencesUtil.setKeeShareContainerUri(context, uuid, uri)
+        assertEquals(uri, PreferencesUtil.getKeeShareContainerUri(context, uuid))
+    }
+
+    @Test
+    fun returnNullForUnknownGroup() {
+        assertNull(PreferencesUtil.getKeeShareContainerUri(context, "nonexistent-uuid"))
+    }
+
+    @Test
+    fun removeContainerUri() {
+        val uuid = "test-uuid"
+        PreferencesUtil.setKeeShareContainerUri(context, uuid, "content://test")
+        PreferencesUtil.setKeeShareContainerUri(context, uuid, null)
+        assertNull(PreferencesUtil.getKeeShareContainerUri(context, uuid))
+    }
+
+    @Test
+    fun multipleGroupsStoredIndependently() {
+        val uuid1 = "uuid-1"
+        val uuid2 = "uuid-2"
+        PreferencesUtil.setKeeShareContainerUri(context, uuid1, "content://file1")
+        PreferencesUtil.setKeeShareContainerUri(context, uuid2, "content://file2")
+        assertEquals("content://file1", PreferencesUtil.getKeeShareContainerUri(context, uuid1))
+        assertEquals("content://file2", PreferencesUtil.getKeeShareContainerUri(context, uuid2))
+    }
+
+    @Test
+    fun overwriteExistingUri() {
+        val uuid = "overwrite-uuid"
+        PreferencesUtil.setKeeShareContainerUri(context, uuid, "content://old")
+        PreferencesUtil.setKeeShareContainerUri(context, uuid, "content://new")
+        assertEquals("content://new", PreferencesUtil.getKeeShareContainerUri(context, uuid))
+    }
+}

--- a/database/src/main/java/com/kunzisoft/keepass/database/element/Database.kt
+++ b/database/src/main/java/com/kunzisoft/keepass/database/element/Database.kt
@@ -285,6 +285,9 @@ open class Database {
     val allowDataCompression: Boolean
         get() = mDatabaseKDBX != null
 
+    val supportsKeeShare: Boolean
+        get() = mDatabaseKDBX != null
+
     val availableCompressionAlgorithms: List<CompressionAlgorithm>
         get() = mDatabaseKDBX?.availableCompressionAlgorithms ?: emptyList()
 
@@ -443,6 +446,12 @@ open class Database {
         return mDatabaseKDB?.getAllGroupsWithoutRoot()?.map { Group(it) }
             ?: mDatabaseKDBX?.getAllGroupsWithoutRoot()?.map { Group(it) }
             ?: listOf()
+    }
+
+    fun forEachGroupWithCustomData(action: (Group) -> Unit) {
+        mDatabaseKDBX?.getGroupIndexes()
+            ?.filter { it.customData.isNotEmpty() }
+            ?.forEach { action(Group(it)) }
     }
 
     val manageHistory: Boolean

--- a/database/src/main/java/com/kunzisoft/keepass/database/keeshare/KeeShareExport.kt
+++ b/database/src/main/java/com/kunzisoft/keepass/database/keeshare/KeeShareExport.kt
@@ -1,0 +1,84 @@
+/*
+ * Copyright 2026 Jeremy Jamet / Kunzisoft.
+ *
+ * This file is part of KeePassDX.
+ *
+ *  KeePassDX is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  KeePassDX is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with KeePassDX.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+package com.kunzisoft.keepass.database.keeshare
+
+import com.kunzisoft.keepass.database.element.Database
+import com.kunzisoft.keepass.database.element.Entry
+import com.kunzisoft.keepass.database.element.Group
+import com.kunzisoft.keepass.database.element.MasterCredential
+import com.kunzisoft.keepass.database.element.node.NodeHandler
+import com.kunzisoft.keepass.hardware.HardwareKey
+import java.io.File
+import java.io.OutputStream
+
+object KeeShareExport {
+
+    fun exportSharedGroup(
+        sourceDatabase: Database,
+        sharedGroup: Group,
+        reference: KeeShareReference,
+        cacheFile: File,
+        outputStreamProvider: () -> OutputStream?,
+        challengeResponseRetriever: (HardwareKey, ByteArray?) -> ByteArray
+    ) {
+        if (!reference.isExporting) return
+
+        val containerDb = Database()
+        containerDb.createData("KeeShare", sharedGroup.title, null)
+
+        val containerRoot = containerDb.rootGroup ?: return
+
+        sharedGroup.doForEachChild(
+            object : NodeHandler<Entry>() {
+                override fun operate(node: Entry): Boolean {
+                    containerDb.createEntry()?.let { newEntry ->
+                        newEntry.nodeId = node.nodeId
+                        newEntry.title = node.title
+                        newEntry.username = node.username
+                        newEntry.password = node.password
+                        newEntry.url = node.url
+                        newEntry.notes = node.notes
+                        newEntry.icon = node.icon
+                        newEntry.tags = node.tags
+                        containerDb.addEntryTo(newEntry, containerRoot)
+                    }
+                    return true
+                }
+            },
+            null
+        )
+
+        val credential = if (reference.password.isNotEmpty()) {
+            MasterCredential(reference.password.toCharArray())
+        } else {
+            MasterCredential(CharArray(0))
+        }
+
+        containerDb.saveData(
+            cacheFile,
+            outputStreamProvider,
+            true,
+            credential,
+            challengeResponseRetriever
+        )
+
+        containerDb.clearAndClose()
+    }
+}

--- a/database/src/main/java/com/kunzisoft/keepass/database/keeshare/KeeShareReference.kt
+++ b/database/src/main/java/com/kunzisoft/keepass/database/keeshare/KeeShareReference.kt
@@ -1,0 +1,194 @@
+/*
+ * Copyright 2026 Jeremy Jamet / Kunzisoft.
+ *
+ * This file is part of KeePassDX.
+ *
+ *  KeePassDX is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  KeePassDX is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with KeePassDX.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+package com.kunzisoft.keepass.database.keeshare
+
+import android.util.Base64
+import com.kunzisoft.keepass.database.element.CustomData
+import org.xmlpull.v1.XmlPullParser
+import org.xmlpull.v1.XmlPullParserFactory
+import org.xmlpull.v1.XmlSerializer
+import java.io.StringReader
+import java.io.StringWriter
+import java.nio.ByteBuffer
+import java.util.UUID
+
+data class KeeShareReference(
+    val type: Int = INACTIVE,
+    val uuid: UUID = UUID(0, 0),
+    val path: String = "",
+    val password: String = "",
+    val keepGroups: Boolean = false
+) {
+
+    val isImporting: Boolean get() = type and IMPORT_FROM != 0 && path.isNotEmpty()
+
+    val isExporting: Boolean get() = type and EXPORT_TO != 0 && path.isNotEmpty()
+
+    val isValid: Boolean get() = type != INACTIVE && path.isNotEmpty()
+
+    fun serialize(): String {
+        val writer = StringWriter()
+        val serializer = XmlPullParserFactory.newInstance().newSerializer()
+        serializer.setOutput(writer)
+        serializer.startDocument("UTF-8", null)
+        serializer.startTag(null, TAG_ROOT)
+
+        serializer.startTag(null, TAG_TYPE)
+        if (type and IMPORT_FROM != 0) serializer.emptyTag(TAG_IMPORT)
+        if (type and EXPORT_TO != 0) serializer.emptyTag(TAG_EXPORT)
+        serializer.endTag(null, TAG_TYPE)
+
+        serializer.textElement(TAG_GROUP, uuidToBase64(uuid))
+        serializer.textElement(TAG_PATH, Base64.encodeToString(path.toByteArray(), Base64.NO_WRAP))
+        serializer.textElement(TAG_PASSWORD, Base64.encodeToString(password.toByteArray(), Base64.NO_WRAP))
+        serializer.textElement(TAG_KEEP_GROUPS, if (keepGroups) "True" else "False")
+
+        serializer.endTag(null, TAG_ROOT)
+        serializer.endDocument()
+        return Base64.encodeToString(writer.toString().toByteArray(), Base64.NO_WRAP)
+    }
+
+    companion object {
+        const val CUSTOM_DATA_KEY = "KeeShare/Reference"
+
+        const val INACTIVE = 0
+        const val IMPORT_FROM = 1
+        const val EXPORT_TO = 2
+        const val SYNCHRONIZE = IMPORT_FROM or EXPORT_TO
+
+        private const val TAG_ROOT = "KeeShare"
+        private const val TAG_TYPE = "Type"
+        private const val TAG_IMPORT = "Import"
+        private const val TAG_EXPORT = "Export"
+        private const val TAG_GROUP = "Group"
+        private const val TAG_PATH = "Path"
+        private const val TAG_PASSWORD = "Password"
+        private const val TAG_KEEP_GROUPS = "KeepGroups"
+
+        fun fromCustomData(customData: CustomData): KeeShareReference? {
+            val value = customData.get(CUSTOM_DATA_KEY)?.value ?: return null
+            return deserialize(value)
+        }
+
+        fun deserialize(base64Xml: String): KeeShareReference? {
+            val xml = try {
+                String(Base64.decode(base64Xml, Base64.DEFAULT), Charsets.UTF_8)
+            } catch (_: Exception) {
+                base64Xml
+            }
+            return try {
+                parseXml(xml)
+            } catch (_: Exception) {
+                null
+            }
+        }
+
+        private fun parseXml(xml: String): KeeShareReference? {
+            val factory = XmlPullParserFactory.newInstance()
+            val parser = factory.newPullParser()
+            parser.setInput(StringReader(xml))
+
+            var typeFlags = 0
+            var uuid = UUID(0, 0)
+            var path = ""
+            var password = ""
+            var keepGroups = false
+            var insideType = false
+            var currentTag = ""
+
+            var eventType = parser.eventType
+            while (eventType != XmlPullParser.END_DOCUMENT) {
+                when (eventType) {
+                    XmlPullParser.START_TAG -> {
+                        val name = parser.name
+                        if (name == TAG_TYPE) {
+                            insideType = true
+                        } else if (insideType) {
+                            when (name) {
+                                TAG_IMPORT -> typeFlags = typeFlags or IMPORT_FROM
+                                TAG_EXPORT -> typeFlags = typeFlags or EXPORT_TO
+                            }
+                        } else {
+                            currentTag = name
+                        }
+                    }
+                    XmlPullParser.TEXT -> {
+                        val text = parser.text?.trim() ?: ""
+                        if (text.isNotEmpty()) {
+                            if (insideType) {
+                                text.toIntOrNull()?.let { typeFlags = it }
+                            } else when (currentTag) {
+                                TAG_GROUP -> uuidFromBase64(text)?.let { uuid = it }
+                                TAG_PATH -> path = decodeBase64OrPlain(text)
+                                TAG_PASSWORD -> password = decodeBase64OrPlain(text)
+                                TAG_KEEP_GROUPS -> keepGroups = text.equals("True", ignoreCase = true)
+                            }
+                        }
+                    }
+                    XmlPullParser.END_TAG -> {
+                        if (parser.name == TAG_TYPE) insideType = false
+                        currentTag = ""
+                    }
+                }
+                eventType = parser.next()
+            }
+
+            if (typeFlags == INACTIVE && path.isEmpty()) return null
+            return KeeShareReference(typeFlags, uuid, path, password, keepGroups)
+        }
+
+        private fun decodeBase64OrPlain(text: String): String {
+            return try {
+                String(Base64.decode(text, Base64.DEFAULT), Charsets.UTF_8)
+            } catch (_: Exception) {
+                text
+            }
+        }
+
+        private fun uuidFromBase64(base64: String): UUID? {
+            return try {
+                val bytes = Base64.decode(base64, Base64.DEFAULT)
+                if (bytes.size != 16) return null
+                val buf = ByteBuffer.wrap(bytes)
+                UUID(buf.long, buf.long)
+            } catch (_: Exception) {
+                try { UUID.fromString(base64) } catch (_: Exception) { null }
+            }
+        }
+
+        private fun uuidToBase64(uuid: UUID): String {
+            val buf = ByteBuffer.allocate(16)
+            buf.putLong(uuid.mostSignificantBits)
+            buf.putLong(uuid.leastSignificantBits)
+            return Base64.encodeToString(buf.array(), Base64.NO_WRAP)
+        }
+
+        private fun XmlSerializer.emptyTag(name: String) {
+            startTag(null, name)
+            endTag(null, name)
+        }
+
+        private fun XmlSerializer.textElement(name: String, text: String) {
+            startTag(null, name)
+            this.text(text)
+            endTag(null, name)
+        }
+    }
+}

--- a/database/src/test/kotlin/com/kunzisoft/keepass/database/keeshare/KeeShareReferenceTest.kt
+++ b/database/src/test/kotlin/com/kunzisoft/keepass/database/keeshare/KeeShareReferenceTest.kt
@@ -1,0 +1,165 @@
+/*
+ * Copyright 2026 Jeremy Jamet / Kunzisoft.
+ *
+ * This file is part of KeePassDX.
+ *
+ *  KeePassDX is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  KeePassDX is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with KeePassDX.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+package com.kunzisoft.keepass.database.keeshare
+
+import android.util.Base64
+import com.kunzisoft.keepass.database.element.CustomData
+import com.kunzisoft.keepass.database.element.CustomDataItem
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+
+@RunWith(RobolectricTestRunner::class)
+@Config(sdk = [34])
+class KeeShareReferenceTest {
+
+    @Test
+    fun parseImportOnlyReference() {
+        val xml = """
+            <?xml version="1.0" encoding="UTF-8"?>
+            <KeeShare>
+                <Type><Import/></Type>
+                <Group>AAAAAAAAAAAAAAAAAAAAAA==</Group>
+                <Path>${Base64.encodeToString("/shared/passwords.kdbx".toByteArray(), Base64.NO_WRAP)}</Path>
+                <Password>${Base64.encodeToString("secret".toByteArray(), Base64.NO_WRAP)}</Password>
+                <KeepGroups>False</KeepGroups>
+            </KeeShare>
+        """.trimIndent()
+        val encoded = Base64.encodeToString(xml.toByteArray(), Base64.NO_WRAP)
+
+        val ref = KeeShareReference.deserialize(encoded)
+        assertNotNull(ref)
+        assertEquals(KeeShareReference.IMPORT_FROM, ref!!.type)
+        assertTrue(ref.isImporting)
+        assertFalse(ref.isExporting)
+        assertEquals("/shared/passwords.kdbx", ref.path)
+        assertEquals("secret", ref.password)
+        assertFalse(ref.keepGroups)
+    }
+
+    @Test
+    fun parseSynchronizeReference() {
+        val xml = """
+            <?xml version="1.0" encoding="UTF-8"?>
+            <KeeShare>
+                <Type><Import/><Export/></Type>
+                <Group>AAAAAAAAAAAAAAAAAAAAAA==</Group>
+                <Path>${Base64.encodeToString("/sync/db.kdbx".toByteArray(), Base64.NO_WRAP)}</Path>
+                <Password></Password>
+                <KeepGroups>True</KeepGroups>
+            </KeeShare>
+        """.trimIndent()
+        val encoded = Base64.encodeToString(xml.toByteArray(), Base64.NO_WRAP)
+
+        val ref = KeeShareReference.deserialize(encoded)
+        assertNotNull(ref)
+        assertEquals(KeeShareReference.SYNCHRONIZE, ref!!.type)
+        assertTrue(ref.isImporting)
+        assertTrue(ref.isExporting)
+        assertTrue(ref.keepGroups)
+    }
+
+    @Test
+    fun parseLegacyIntegerType() {
+        val xml = """
+            <?xml version="1.0" encoding="UTF-8"?>
+            <KeeShare>
+                <Type>3</Type>
+                <Group>AAAAAAAAAAAAAAAAAAAAAA==</Group>
+                <Path>${Base64.encodeToString("/path".toByteArray(), Base64.NO_WRAP)}</Path>
+                <Password></Password>
+            </KeeShare>
+        """.trimIndent()
+        val encoded = Base64.encodeToString(xml.toByteArray(), Base64.NO_WRAP)
+
+        val ref = KeeShareReference.deserialize(encoded)
+        assertNotNull(ref)
+        assertEquals(KeeShareReference.SYNCHRONIZE, ref!!.type)
+    }
+
+    @Test
+    fun returnNullForInactiveEmptyPath() {
+        val xml = """
+            <?xml version="1.0" encoding="UTF-8"?>
+            <KeeShare>
+                <Type>0</Type>
+                <Group>AAAAAAAAAAAAAAAAAAAAAA==</Group>
+                <Path></Path>
+                <Password></Password>
+            </KeeShare>
+        """.trimIndent()
+        val encoded = Base64.encodeToString(xml.toByteArray(), Base64.NO_WRAP)
+
+        assertNull(KeeShareReference.deserialize(encoded))
+    }
+
+    @Test
+    fun returnNullForGarbage() {
+        assertNull(KeeShareReference.deserialize("not-valid-at-all!!!"))
+    }
+
+    @Test
+    fun fromCustomDataFindsReference() {
+        val xml = """
+            <?xml version="1.0" encoding="UTF-8"?>
+            <KeeShare>
+                <Type><Import/></Type>
+                <Group>AAAAAAAAAAAAAAAAAAAAAA==</Group>
+                <Path>${Base64.encodeToString("/test".toByteArray(), Base64.NO_WRAP)}</Path>
+                <Password></Password>
+            </KeeShare>
+        """.trimIndent()
+        val encoded = Base64.encodeToString(xml.toByteArray(), Base64.NO_WRAP)
+
+        val customData = CustomData()
+        customData.put(CustomDataItem(KeeShareReference.CUSTOM_DATA_KEY, encoded))
+        val ref = KeeShareReference.fromCustomData(customData)
+        assertNotNull(ref)
+        assertEquals("/test", ref!!.path)
+    }
+
+    @Test
+    fun fromCustomDataReturnsNullWhenMissing() {
+        assertNull(KeeShareReference.fromCustomData(CustomData()))
+    }
+
+    @Test
+    fun roundTripSerializeDeserialize() {
+        val original = KeeShareReference(
+            type = KeeShareReference.SYNCHRONIZE,
+            path = "/shared/db.kdbx",
+            password = "mypass",
+            keepGroups = true
+        )
+        val serialized = original.serialize()
+        val parsed = KeeShareReference.deserialize(serialized)
+        assertNotNull(parsed)
+        assertEquals(original.type, parsed!!.type)
+        assertEquals(original.path, parsed.path)
+        assertEquals(original.password, parsed.password)
+        assertEquals(original.keepGroups, parsed.keepGroups)
+    }
+}


### PR DESCRIPTION
Depends on #2544.

Export shared group entries to a KeeShare container .kdbx, matching KeePassXC's export behavior. Entries cloned with UUIDs and timestamps preserved for merge compatibility.

Triggered by `KeeShareExport.exportSharedGroup()` — not yet wired to the save flow (follow-up).

8 instrumented tests: container creation, import back, entry isolation, round-trip, inactive/import-only no-ops, entry count, bidirectional sync.

Ref: #2438, #2434