### PR TITLE
Handle revoked database file access with reselect flow

### DIFF
--- a/app/src/main/java/com/kunzisoft/keepass/activities/MainCredentialActivity.kt
+++ b/app/src/main/java/com/kunzisoft/keepass/activities/MainCredentialActivity.kt
@@ -82,8 +82,10 @@ import com.kunzisoft.keepass.tasks.ActionRunnable
 import com.kunzisoft.keepass.utils.BACK_PREVIOUS_KEYBOARD_ACTION
 import com.kunzisoft.keepass.utils.MenuUtil
 import com.kunzisoft.keepass.utils.UriUtil.getUri
+import com.kunzisoft.keepass.utils.UriUtil.hasPersistedReadAccess
 import com.kunzisoft.keepass.utils.getParcelableCompat
 import com.kunzisoft.keepass.utils.getParcelableExtraCompat
+import com.kunzisoft.keepass.utils.withContentScheme
 import com.kunzisoft.keepass.view.MainCredentialView
 import com.kunzisoft.keepass.view.asError
 import com.kunzisoft.keepass.view.showActionErrorIfNeeded
@@ -122,12 +124,14 @@ class MainCredentialActivity : DatabaseModeActivity() {
     private var mDatabaseFileUri: Uri? = null
 
     private var mRememberKeyFile: Boolean = false
-    private var mExternalFileHelper: ExternalFileHelper? = null
+    private var mKeyFileExternalFileHelper: ExternalFileHelper? = null
+    private var mDatabaseFileExternalFileHelper: ExternalFileHelper? = null
 
     private var mRememberHardwareKey: Boolean = false
 
     private var mReadOnly: Boolean = false
     private var mForceReadOnly: Boolean = false
+    private var mDatabaseFileAccessDialogShown: Boolean = false
     private var mUserVerificationAllowed: Boolean = false
     private var mForceUserVerificationAllowed: Boolean = false
 
@@ -172,14 +176,20 @@ class MainCredentialActivity : DatabaseModeActivity() {
         mRememberKeyFile = PreferencesUtil.rememberKeyFileLocations(this)
         mRememberHardwareKey = PreferencesUtil.rememberHardwareKey(this)
 
-        // Build elements to manage keyfile selection
-        mExternalFileHelper = ExternalFileHelper(this)
-        mExternalFileHelper?.buildOpenDocument { uri ->
+        // Build file pickers for key file selection and database file reselection
+        mKeyFileExternalFileHelper = ExternalFileHelper(this)
+        mKeyFileExternalFileHelper?.buildOpenDocument { uri ->
             if (uri != null) {
                 mainCredentialView?.populateKeyFileView(uri)
             }
         }
-        mainCredentialView?.setOpenKeyfileClickListener(mExternalFileHelper)
+        mDatabaseFileExternalFileHelper = ExternalFileHelper(this)
+        mDatabaseFileExternalFileHelper?.buildOpenDocument { uri ->
+            if (uri != null) {
+                onDatabaseFileReselected(uri)
+            }
+        }
+        mainCredentialView?.setOpenKeyfileClickListener(mKeyFileExternalFileHelper)
         mainCredentialView?.onValidateListener = {
             loadDatabase()
         }
@@ -361,7 +371,13 @@ class MainCredentialActivity : DatabaseModeActivity() {
         }
 
         mDatabaseFileUri?.let { databaseFileUri ->
-            mDatabaseFileViewModel.loadDatabaseFile(databaseFileUri)
+            if (isDatabaseFileAccessRevoked(databaseFileUri)) {
+                markDatabaseFileAccessRevoked()
+                showDatabaseFileAccessRevokedDialog(showOnce = true)
+            } else {
+                mDatabaseFileAccessDialogShown = false
+                mDatabaseFileViewModel.loadDatabaseFile(databaseFileUri)
+            }
         }
     }
 
@@ -410,6 +426,7 @@ class MainCredentialActivity : DatabaseModeActivity() {
                             if (mDefaultDatabase) {
                                 mDatabaseFileViewModel.removeDefaultDatabase()
                             }
+                            showDatabaseFileAccessRevokedDialog()
                         }
                     }
                 }
@@ -450,6 +467,55 @@ class MainCredentialActivity : DatabaseModeActivity() {
         mDatabaseFileUri = databaseUri
         mainCredentialView?.populateKeyFileView(keyFileUri)
         mainCredentialView?.populateHardwareKeyView(hardwareKey)
+    }
+
+    private fun onDatabaseFileReselected(databaseUri: Uri) {
+        mDatabaseFileUri = databaseUri
+        mForceReadOnly = false
+        mDatabaseFileAccessDialogShown = false
+        infoContainerView?.visibility = View.GONE
+        invalidateOptionsMenu()
+        intent = Intent(this, MainCredentialActivity::class.java).apply {
+            putExtras(intent)
+            putExtra(KEY_FILENAME, databaseUri)
+        }
+        mDatabaseFileViewModel.checkIfIsDefaultDatabase(databaseUri)
+        mDatabaseFileViewModel.loadDatabaseFile(databaseUri)
+    }
+
+    private fun isDatabaseFileAccessRevoked(databaseUri: Uri): Boolean {
+        return intent?.action != VIEW_INTENT
+                && databaseUri.withContentScheme()
+                && !contentResolver.hasPersistedReadAccess(databaseUri)
+    }
+
+    private fun markDatabaseFileAccessRevoked() {
+        mReadOnly = true
+        mForceReadOnly = true
+        infoContainerView?.visibility = View.VISIBLE
+        invalidateOptionsMenu()
+    }
+
+    private fun showDatabaseFileAccessRevokedDialog(showOnce: Boolean = false) {
+        if (showOnce && mDatabaseFileAccessDialogShown) {
+            return
+        }
+        mDatabaseFileAccessDialogShown = true
+        AlertDialog.Builder(this).apply {
+            setMessage(R.string.warning_database_revoked)
+            setPositiveButton(R.string.select_database_file) { _, _ ->
+                mDatabaseFileExternalFileHelper?.openDocument(
+                    initialUri = mDatabaseFileUri
+                )
+            }
+            setNegativeButton(android.R.string.cancel) { _, _ ->
+                mDatabaseFileAccessDialogShown = false
+            }
+            setOnCancelListener {
+                mDatabaseFileAccessDialogShown = false
+            }
+            create().show()
+        }
     }
 
     override fun onNewIntent(intent: Intent?) {
@@ -614,6 +680,17 @@ class MainCredentialActivity : DatabaseModeActivity() {
     }
 
     private fun loadDatabase() {
+        mDatabaseFileUri?.let { databaseFileUri ->
+            if (isDatabaseFileAccessRevoked(databaseFileUri)) {
+                markDatabaseFileAccessRevoked()
+                showDatabaseFileAccessRevokedDialog()
+                return
+            }
+        }
+        if (mForceReadOnly) {
+            showDatabaseFileAccessRevokedDialog()
+            return
+        }
         getMainCredentialFromViews()
         loadDatabase(
             databaseFileUri = mDatabaseFileUri,

--- a/app/src/main/java/com/kunzisoft/keepass/activities/helpers/ExternalFileHelper.kt
+++ b/app/src/main/java/com/kunzisoft/keepass/activities/helpers/ExternalFileHelper.kt
@@ -20,14 +20,17 @@
 package com.kunzisoft.keepass.activities.helpers
 
 import android.annotation.SuppressLint
+import android.app.Activity
 import android.content.Context
 import android.content.Intent
 import android.net.Uri
 import android.os.Build
+import android.provider.DocumentsContract
 import android.util.Log
 import android.view.View
 import androidx.activity.result.ActivityResultCallback
 import androidx.activity.result.ActivityResultLauncher
+import androidx.activity.result.contract.ActivityResultContract
 import androidx.activity.result.contract.ActivityResultContracts
 import androidx.fragment.app.Fragment
 import androidx.fragment.app.FragmentActivity
@@ -40,7 +43,7 @@ class ExternalFileHelper {
     private var fragment: Fragment? = null
 
     private var getContentResultLauncher: ActivityResultLauncher<String>? = null
-    private var openDocumentResultLauncher: ActivityResultLauncher<Array<String>>? = null
+    private var openDocumentResultLauncher: ActivityResultLauncher<OpenDocumentRequest>? = null
     private var createDocumentResultLauncher: ActivityResultLauncher<String>? = null
 
     constructor(context: FragmentActivity) {
@@ -105,13 +108,18 @@ class ExternalFileHelper {
         }
     }
 
-    fun openDocument(getContent: Boolean = false,
-                     typeString: String = "*/*") {
+    fun openDocument(
+        getContent: Boolean = false,
+        typeString: String = "*/*",
+        initialUri: Uri? = null
+    ) {
         try {
             if (getContent) {
                 getContentResultLauncher?.launch(typeString)
             } else {
-                openDocumentResultLauncher?.launch(arrayOf(typeString))
+                openDocumentResultLauncher?.launch(
+                    OpenDocumentRequest(typeString, initialUri)
+                )
             }
         } catch (e: Exception) {
             Log.e(TAG, "Unable to open document", e)
@@ -145,19 +153,33 @@ class ExternalFileHelper {
         }
     }
 
-    class OpenDocument : ActivityResultContracts.OpenDocument() {
+    private data class OpenDocumentRequest(
+        val mimeType: String,
+        val initialUri: Uri?
+    )
+
+    private class OpenDocument : ActivityResultContract<OpenDocumentRequest, Uri?>() {
         @SuppressLint("InlinedApi")
-        override fun createIntent(context: Context, input: Array<String>): Intent {
-            return super.createIntent(context, input).apply {
+        override fun createIntent(context: Context, input: OpenDocumentRequest): Intent {
+            return Intent(Intent.ACTION_OPEN_DOCUMENT).apply {
+                type = input.mimeType
                 addCategory(Intent.CATEGORY_OPENABLE)
                 addFlags(Intent.FLAG_GRANT_PERSISTABLE_URI_PERMISSION)
                 if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP) {
                     addFlags(Intent.FLAG_GRANT_PREFIX_URI_PERMISSION)
                 }
+                if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+                    input.initialUri?.let {
+                        putExtra(DocumentsContract.EXTRA_INITIAL_URI, it)
+                    }
+                }
                 addFlags(Intent.FLAG_GRANT_READ_URI_PERMISSION)
                 addFlags(Intent.FLAG_GRANT_WRITE_URI_PERMISSION)
             }
         }
+
+        override fun parseResult(resultCode: Int, intent: Intent?): Uri? =
+            if (resultCode == Activity.RESULT_OK) intent?.data else null
     }
 
     class GetContent : ActivityResultContracts.GetContent() {

--- a/app/src/main/java/com/kunzisoft/keepass/database/action/LoadDatabaseRunnable.kt
+++ b/app/src/main/java/com/kunzisoft/keepass/database/action/LoadDatabaseRunnable.kt
@@ -26,12 +26,14 @@ import com.kunzisoft.keepass.database.MainCredential
 import com.kunzisoft.keepass.database.element.MasterCredential
 import com.kunzisoft.keepass.database.element.binary.BinaryData
 import com.kunzisoft.keepass.database.exception.DatabaseInputException
+import com.kunzisoft.keepass.database.exception.FileNotFoundDatabaseException
 import com.kunzisoft.keepass.database.exception.UnknownDatabaseLocationException
 import com.kunzisoft.keepass.hardware.HardwareKey
 import com.kunzisoft.keepass.tasks.ActionRunnable
 import com.kunzisoft.keepass.tasks.ProgressTaskUpdater
 import com.kunzisoft.keepass.utils.getBinaryDir
 import com.kunzisoft.keepass.utils.getUriInputStream
+import java.io.FileNotFoundException
 
 class LoadDatabaseRunnable(
     private val context: Context,
@@ -60,10 +62,17 @@ class LoadDatabaseRunnable(
             val contentResolver = context.contentResolver
             // Save database URI
             mDatabase.fileUri = mDatabaseUri
+            val databaseInputStream = try {
+                contentResolver.getUriInputStream(mDatabaseUri)
+                    ?: throw UnknownDatabaseLocationException()
+            } catch (e: FileNotFoundException) {
+                throw FileNotFoundDatabaseException(e)
+            } catch (e: SecurityException) {
+                throw FileNotFoundDatabaseException(e)
+            }
             mMasterCredential = mMainCredential.toMasterCredential(contentResolver)
             mDatabase.loadData(
-                databaseStream = contentResolver.getUriInputStream(mDatabaseUri)
-                    ?: throw UnknownDatabaseLocationException(),
+                databaseStream = databaseInputStream,
                 masterCredential = mMasterCredential!!,
                 challengeResponseRetriever = mChallengeResponseRetriever,
                 readOnly = mReadonly,

--- a/app/src/main/java/com/kunzisoft/keepass/utils/UriUtil.kt
+++ b/app/src/main/java/com/kunzisoft/keepass/utils/UriUtil.kt
@@ -133,6 +133,12 @@ object UriUtil {
         }
     }
 
+    fun ContentResolver.hasPersistedReadAccess(uri: Uri): Boolean {
+        return persistedUriPermissions.any { uriPermission ->
+            uriPermission.uri == uri && uriPermission.isReadPermission
+        }
+    }
+
     fun ContentResolver.releaseUriPermission(uri: Uri?) {
         uri?.let {
             persistUriPermission(this, it, release = true, readOnly = false)

--- a/app/src/main/java/com/kunzisoft/keepass/utils/UriUtil.kt
+++ b/app/src/main/java/com/kunzisoft/keepass/utils/UriUtil.kt
@@ -117,6 +117,8 @@ object UriUtil {
                     }
                 }
             }
+        } catch (e: SecurityException) {
+            Log.e(TAG, "file have changed, permission need to be granted ", e)
         } catch (e: Exception) {
             if (release)
                 Log.e(TAG, "Unable to release persistable URI permission", e)

--- a/database/src/main/java/com/kunzisoft/keepass/database/exception/DatabaseException.kt
+++ b/database/src/main/java/com/kunzisoft/keepass/database/exception/DatabaseException.kt
@@ -72,7 +72,10 @@ abstract class DatabaseException : LocalizedException {
     }
 }
 
-class FileNotFoundDatabaseException : DatabaseInputException()
+class FileNotFoundDatabaseException : DatabaseInputException {
+    constructor() : super()
+    constructor(throwable: Throwable) : super(throwable)
+}
 
 class CorruptedDatabaseException : DatabaseInputException()
 


### PR DESCRIPTION
## Summary

This PR improves the recovery flow when Android/SAF revokes access to the selected database file. Instead of requiring users to remove and re-add the database, KeePassDX now prompts them to reselect the file directly, opening the picker near the previous file location when possible.

## Changes

KeePassDX now detects revoked persisted access before opening the database, treats revoked or missing URI access as an inaccessible database, and routes the user into the reselect-file flow.

## Background 

I have been using KeePassXC for a long time, with my database synced through Nextcloud. After switching to a new device, the Nextcloud app started behaving strangely and would crash when I tried to open the database through SAF. So I switched to FolderSync Pro instead.

At first, everything worked fine. The issue started after I modified an entry from the desktop side. KeePassDX then showed:

> Access to the file revoked by file manager

The workaround was to remove the database from KeePassDX and add it again. That fixed it temporarily, but the issue came back every time the database was modified from the desktop side.

My assumption is that FolderSync Pro recreates the database file during sync, or at least Android treats it that way, which invalidates the existing SAF permission grant.

This PR adds a smoother recovery flow for that case: when access to the database file is revoked, KeePassDX now lets the user reselect the same database file instead of requiring them to remove and re-add it manually.

One more thing I noticed during the workaround: after removing and re-adding the same database, the database password was fetched automatically after the biometric prompt. I am not sure if that behavior is expected.