### PR TITLE
Argon2 perf: use persistent threads instead of one per segment

### DIFF
--- a/crypto/src/androidTest/java/com/kunzisoft/encrypt/Argon2BenchmarkTest.kt
+++ b/crypto/src/androidTest/java/com/kunzisoft/encrypt/Argon2BenchmarkTest.kt
@@ -1,0 +1,187 @@
+package com.kunzisoft.encrypt
+
+import android.os.Build
+import android.util.Log
+import com.kunzisoft.encrypt.argon2.Argon2Transformer
+import com.kunzisoft.encrypt.argon2.Argon2Type
+import org.junit.Test
+
+class Argon2BenchmarkTest {
+
+    private val password = "password".toByteArray()
+    private val salt = "saltsaltsaltsalt".toByteArray()
+    private val version = 0x13
+
+    private fun run(
+        type: Argon2Type,
+        iterations: UInt,
+        memory: UInt,
+        parallelism: UInt
+    ): Long {
+        val start = System.nanoTime()
+        Argon2Transformer.transformKey(
+            type = type,
+            password = password,
+            salt = salt,
+            parallelism = parallelism,
+            memory = memory,
+            iterations = iterations,
+            version = version
+        )
+        return (System.nanoTime() - start) / 1_000_000
+    }
+
+    private fun benchmark(
+        type: Argon2Type,
+        iterations: UInt = 3u,
+        memory: UInt = 1024u * 64u, // 64 MB
+        parallelism: UInt = 4u,
+        warmups: Int = 4,
+        runs: Int = 12
+    ) {
+        repeat(warmups) { run(type, iterations, memory, parallelism) }
+
+        val timesMs = LongArray(runs) { run(type, iterations, memory, parallelism) }
+        val sorted = timesMs.sorted()
+        val median = sorted[runs / 2]
+        val avg = timesMs.average()
+        val min = timesMs.min()
+        val max = timesMs.max()
+
+        // Cost is proportional to iterations * memory, so normalizing by it makes
+        // runs with different parameters directly comparable.
+        val mibPasses = iterations.toDouble() * memory.toDouble() / 1024.0
+        val mibPassesPerSec = mibPasses / (median / 1000.0)
+
+        Log.i(TAG, "abi=${Build.SUPPORTED_ABIS.firstOrNull()} device=${Build.MODEL}")
+        Log.i(TAG, "type=$type iter=$iterations memory=${memory}KB parallelism=$parallelism")
+        // Chronological order, not sorted: a run that drifts upward over time
+        // means something else is changing (clocks, placement), and sorting the
+        // list destroys exactly that evidence.
+        Log.i(TAG, "runs(ms) in order=${timesMs.joinToString()}")
+        Log.i(TAG, "sorted=${sorted.joinToString()} median=$median avg=$avg min=$min max=$max")
+        Log.i(TAG, "cost=${mibPasses}MiB-passes throughput=${"%.0f".format(mibPassesPerSec)}MiB-passes/s")
+    }
+
+    @Test
+    fun benchmarkArgon2i() {
+        benchmark(Argon2Type.ARGON2_I)
+    }
+
+    @Test
+    fun benchmarkArgon2d() {
+        benchmark(Argon2Type.ARGON2_D)
+    }
+
+    @Test
+    fun benchmarkArgon2id() {
+        benchmark(Argon2Type.ARGON2_ID)
+    }
+
+    @Test
+    fun benchmarkArgon2dVaultParameters() {
+        benchmark(
+            Argon2Type.ARGON2_D,
+            iterations = 128u,
+            memory = 1024u * 32u, // 32 MiB
+            parallelism = 4u,
+            warmups = 1,
+            runs = 3
+        )
+    }
+
+    /**
+     * Same cost, reshaped towards memory instead of iterations. Should land close
+     * to the run above; if it does not, the bottleneck is memory bandwidth rather
+     * than the compression function.
+     */
+    @Test
+    fun benchmarkArgon2dMemoryHeavy() {
+        benchmark(
+            Argon2Type.ARGON2_D,
+            iterations = 1u,
+            memory = 1024u * 512u, // 512 MiB
+            parallelism = 4u,
+            warmups = 1,
+            runs = 3
+        )
+    }
+
+    /**
+     * Same total cost as [benchmarkArgon2dT2M512] but with the cost put into
+     * iterations instead of memory, which halves the area-time product.
+     */
+    @Test
+    fun benchmarkArgon2dT4M256() {
+        benchmark(
+            Argon2Type.ARGON2_D,
+            iterations = 4u,
+            memory = 1024u * 256u, // 256 MiB
+            parallelism = 4u,
+            warmups = 1,
+            runs = 3
+        )
+    }
+
+    @Test
+    fun benchmarkArgon2dT2M512() {
+        benchmark(
+            Argon2Type.ARGON2_D,
+            iterations = 2u,
+            memory = 1024u * 512u, // 512 MiB
+            parallelism = 4u,
+            warmups = 1,
+            runs = 3
+        )
+    }
+
+    /**
+     * On an asymmetric CPU the lanes join at every sync point, so the slowest
+     * core gates the whole derivation. If fewer lanes are faster than more, the
+     * little cores are the bottleneck rather than the compression function.
+     */
+    @Test
+    fun benchmarkArgon2dTwoLanes() {
+        benchmark(
+            Argon2Type.ARGON2_D,
+            iterations = 128u,
+            memory = 1024u * 32u,
+            parallelism = 2u,
+            warmups = 0,
+            runs = 2
+        )
+    }
+
+    @Test
+    fun benchmarkArgon2dSixLanes() {
+        benchmark(
+            Argon2Type.ARGON2_D,
+            iterations = 128u,
+            memory = 1024u * 32u,
+            parallelism = 6u,
+            warmups = 0,
+            runs = 2
+        )
+    }
+
+    /**
+     * Single lane, to check whether the four Argon2 worker threads are actually
+     * getting four cores. Should be close to 4x the p=4 run; much less than that
+     * means the workers are being scheduled onto little cores.
+     */
+    @Test
+    fun benchmarkArgon2dSingleLane() {
+        benchmark(
+            Argon2Type.ARGON2_D,
+            iterations = 128u,
+            memory = 1024u * 32u,
+            parallelism = 1u,
+            warmups = 0,
+            runs = 2
+        )
+    }
+
+    companion object {
+        private const val TAG = "Argon2Benchmark"
+    }
+}

--- a/crypto/src/main/jni/CMakeLists.txt
+++ b/crypto/src/main/jni/CMakeLists.txt
@@ -2,5 +2,9 @@ cmake_minimum_required(VERSION 3.4.1)
 
 project("crypto")
 
+# LTO: lets the compiler inline/optimize across translation units
+# (e.g. blake2b.c <-> ref.c), portable win on every ABI (armeabi-v7a included).
+set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -flto=thin")
+
 add_subdirectory(aes)
 add_subdirectory(argon2)

--- a/crypto/src/main/jni/aes/CMakeLists.txt
+++ b/crypto/src/main/jni/aes/CMakeLists.txt
@@ -20,4 +20,4 @@ add_library(
 find_library(log-lib log)
 
 target_link_libraries(aes ${log-lib})
-target_link_options(aes PRIVATE "-Wl,-z,max-page-size=16384")
+target_link_options(aes PRIVATE "-Wl,-z,max-page-size=16384" "-flto=thin")

--- a/crypto/src/main/jni/argon2/CMakeLists.txt
+++ b/crypto/src/main/jni/argon2/CMakeLists.txt
@@ -16,4 +16,4 @@ add_library(
     argon2_jni.c
 )
 
-target_link_options(argon2 PRIVATE "-Wl,-z,max-page-size=16384")
+target_link_options(argon2 PRIVATE "-Wl,-z,max-page-size=16384" "-flto=thin")

--- a/crypto/src/main/jni/argon2/src/core.c
+++ b/crypto/src/main/jni/argon2/src/core.c
@@ -246,93 +246,141 @@ uint32_t index_alpha(const argon2_instance_t *instance,
     return absolute_position;
 }
 
+/* A worker lives for the whole derivation and synchronises with the others at
+   every slice, instead of being created and joined once per segment (which was
+   passes * ARGON2_SYNC_POINTS * lanes thread creations, all too short-lived for
+   the scheduler to base frequency and core placement on). */
+typedef struct argon2_worker_data_ {
+    argon2_instance_t *instance;
+    argon2_barrier_t *barrier;
+    uint32_t index;   /* 0 .. workers-1 */
+    uint32_t workers; /* == barrier threshold */
+} argon2_worker_data;
+
+static void fill_lanes(argon2_worker_data *data) {
+    argon2_instance_t *instance = data->instance;
+    uint32_t r, s, l;
+
+    for (r = 0; r < instance->passes; ++r) {
+        for (s = 0; s < ARGON2_SYNC_POINTS; ++s) {
+            /* Round-robin, so fewer workers than lanes still covers every
+               lane. */
+            for (l = data->index; l < instance->lanes; l += data->workers) {
+                argon2_position_t position;
+                position.pass = r;
+                position.lane = l;
+                position.slice = (uint8_t)s;
+                position.index = 0;
+                fill_segment(instance, position);
+            }
+
+            /* Every lane must finish slice s before any lane starts s + 1.
+               A lone worker already did, so it gets no barrier. */
+            if (data->barrier != NULL &&
+                argon2_barrier_wait(data->barrier) != 0) {
+                return; /* aborted */
+            }
+        }
+    }
+}
+
 #ifdef _WIN32
-static unsigned __stdcall fill_segment_thr(void *thread_data)
+static unsigned __stdcall fill_lanes_thr(void *worker_data)
 #else
-static void *fill_segment_thr(void *thread_data)
+static void *fill_lanes_thr(void *worker_data)
 #endif
 {
-    argon2_thread_data *my_data = thread_data;
-    fill_segment(my_data->instance_ptr, my_data->pos);
+    fill_lanes((argon2_worker_data *)worker_data);
     argon2_thread_exit();
     return 0;
 }
 
 int fill_memory_blocks(argon2_instance_t *instance) {
-    uint32_t r, s;
+    uint32_t workers, w, started;
     argon2_thread_handle_t *thread = NULL;
-    argon2_thread_data *thr_data = NULL;
+    argon2_worker_data *thr_data = NULL;
+    argon2_barrier_t barrier;
+    int barrier_ready = 0;
     int rc = ARGON2_OK;
 
     if (instance == NULL || instance->lanes == 0) {
-        rc = ARGON2_THREAD_FAIL;
-        goto fail;
+        return ARGON2_THREAD_FAIL;
     }
 
-    /* 1. Allocating space for threads */
-    thread = calloc(instance->lanes, sizeof(argon2_thread_handle_t));
+    /* More workers than lanes would only add idle barrier participants. */
+    workers = instance->threads;
+    if (workers > instance->lanes) {
+        workers = instance->lanes;
+    }
+    if (workers == 0) {
+        workers = 1;
+    }
+
+    /* 1. Single worker: no threads, no barrier. */
+    if (workers == 1) {
+        argon2_worker_data data;
+        data.instance = instance;
+        data.barrier = NULL;
+        data.index = 0;
+        data.workers = 1;
+        fill_lanes(&data);
+        return ARGON2_OK;
+    }
+
+    /* 2. Allocating space for the workers */
+    thread = calloc(workers, sizeof(argon2_thread_handle_t));
     if (thread == NULL) {
         rc = ARGON2_MEMORY_ALLOCATION_ERROR;
         goto fail;
     }
 
-    thr_data = calloc(instance->lanes, sizeof(argon2_thread_data));
+    thr_data = calloc(workers, sizeof(argon2_worker_data));
     if (thr_data == NULL) {
         rc = ARGON2_MEMORY_ALLOCATION_ERROR;
         goto fail;
     }
 
-    for (r = 0; r < instance->passes; ++r) {
-        for (s = 0; s < ARGON2_SYNC_POINTS; ++s) {
-            uint32_t l;
+    if (argon2_barrier_init(&barrier, workers) != 0) {
+        rc = ARGON2_THREAD_FAIL;
+        goto fail;
+    }
+    barrier_ready = 1;
 
-            /* 2. Calling threads */
-            for (l = 0; l < instance->lanes; ++l) {
-                argon2_position_t position;
+    for (w = 0; w < workers; ++w) {
+        thr_data[w].instance = instance;
+        thr_data[w].barrier = &barrier;
+        thr_data[w].index = w;
+        thr_data[w].workers = workers;
+    }
 
-                /* 2.1 Join a thread if limit is exceeded */
-                if (l >= instance->threads) {
-                    if (argon2_thread_join(thread[l - instance->threads])) {
-                        rc = ARGON2_THREAD_FAIL;
-                        goto fail;
-                    }
-                }
-
-                /* 2.2 Create thread */
-                position.pass = r;
-                position.lane = l;
-                position.slice = (uint8_t)s;
-                position.index = 0;
-                thr_data[l].instance_ptr =
-                    instance; /* preparing the thread input */
-                memcpy(&(thr_data[l].pos), &position,
-                       sizeof(argon2_position_t));
-                if (argon2_thread_create(&thread[l], &fill_segment_thr,
-                                         (void *)&thr_data[l])) {
-                    rc = ARGON2_THREAD_FAIL;
-                    goto fail;
-                }
-
-                /* fill_segment(instance, position); */
-                /*Non-thread equivalent of the lines above */
+    /* 3. Starting workers 1..workers-1; worker 0 runs on the calling thread. */
+    for (started = 1; started < workers; ++started) {
+        if (argon2_thread_create(&thread[started], &fill_lanes_thr,
+                                 (void *)&thr_data[started])) {
+            /* Release whoever already reached the barrier: it will never see
+               the participant count it is waiting for. */
+            argon2_barrier_abort(&barrier);
+            for (w = 1; w < started; ++w) {
+                argon2_thread_join(thread[w]);
             }
-
-            /* 3. Joining remaining threads */
-            for (l = instance->lanes - instance->threads; l < instance->lanes;
-                 ++l) {
-                if (argon2_thread_join(thread[l])) {
-                    rc = ARGON2_THREAD_FAIL;
-                    goto fail;
-                }
-            }
+            rc = ARGON2_THREAD_FAIL;
+            goto fail;
         }
+    }
 
-#ifdef GENKAT
-        internal_kat(instance, r); /* Print all memory blocks */
-#endif
+    /* 4. The calling thread takes worker 0, then joins the rest. */
+    fill_lanes(&thr_data[0]);
+
+    for (w = 1; w < workers; ++w) {
+        if (argon2_thread_join(thread[w])) {
+            rc = ARGON2_THREAD_FAIL;
+        }
     }
 
 fail:
+    if (barrier_ready) {
+        argon2_barrier_destroy(&barrier);
+    }
     if (thread != NULL) {
         free(thread);
     }

--- a/crypto/src/main/jni/argon2/src/thread.c
+++ b/crypto/src/main/jni/argon2/src/thread.c
@@ -51,3 +51,109 @@ void argon2_thread_exit(void) {
     pthread_exit(NULL);
 #endif
 }
+
+int argon2_barrier_init(argon2_barrier_t *barrier, unsigned int threshold) {
+    if (barrier == NULL || threshold == 0) {
+        return -1;
+    }
+
+    barrier->threshold = threshold;
+    barrier->waiting = 0;
+    barrier->generation = 0;
+    barrier->aborted = 0;
+
+#if defined(_WIN32)
+    InitializeCriticalSection(&barrier->mutex);
+    InitializeConditionVariable(&barrier->cond);
+    return 0;
+#else
+    if (pthread_mutex_init(&barrier->mutex, NULL) != 0) {
+        return -1;
+    }
+    if (pthread_cond_init(&barrier->cond, NULL) != 0) {
+        pthread_mutex_destroy(&barrier->mutex);
+        return -1;
+    }
+    return 0;
+#endif
+}
+
+int argon2_barrier_wait(argon2_barrier_t *barrier) {
+    unsigned int generation;
+    int rc = 0;
+
+    if (barrier == NULL) {
+        return -1;
+    }
+
+#if defined(_WIN32)
+    EnterCriticalSection(&barrier->mutex);
+#else
+    pthread_mutex_lock(&barrier->mutex);
+#endif
+
+    if (barrier->aborted) {
+        rc = -1;
+    } else if (++barrier->waiting == barrier->threshold) {
+        /* Last one in opens the barrier. */
+        barrier->waiting = 0;
+        barrier->generation++;
+#if defined(_WIN32)
+        WakeAllConditionVariable(&barrier->cond);
+#else
+        pthread_cond_broadcast(&barrier->cond);
+#endif
+    } else {
+        /* The generation guards against spurious wakeups and against a fast
+           participant lapping the others into the next segment. */
+        generation = barrier->generation;
+        while (generation == barrier->generation && !barrier->aborted) {
+#if defined(_WIN32)
+            SleepConditionVariableCS(&barrier->cond, &barrier->mutex, INFINITE);
+#else
+            pthread_cond_wait(&barrier->cond, &barrier->mutex);
+#endif
+        }
+        if (barrier->aborted) {
+            rc = -1;
+        }
+    }
+
+#if defined(_WIN32)
+    LeaveCriticalSection(&barrier->mutex);
+#else
+    pthread_mutex_unlock(&barrier->mutex);
+#endif
+    return rc;
+}
+
+void argon2_barrier_abort(argon2_barrier_t *barrier) {
+    if (barrier == NULL) {
+        return;
+    }
+
+#if defined(_WIN32)
+    EnterCriticalSection(&barrier->mutex);
+    barrier->aborted = 1;
+    WakeAllConditionVariable(&barrier->cond);
+    LeaveCriticalSection(&barrier->mutex);
+#else
+    pthread_mutex_lock(&barrier->mutex);
+    barrier->aborted = 1;
+    pthread_cond_broadcast(&barrier->cond);
+    pthread_mutex_unlock(&barrier->mutex);
+#endif
+}
+
+void argon2_barrier_destroy(argon2_barrier_t *barrier) {
+    if (barrier == NULL) {
+        return;
+    }
+
+#if defined(_WIN32)
+    DeleteCriticalSection(&barrier->mutex);
+#else
+    pthread_cond_destroy(&barrier->cond);
+    pthread_mutex_destroy(&barrier->mutex);
+#endif
+}

--- a/crypto/src/main/jni/argon2/src/thread.h
+++ b/crypto/src/main/jni/argon2/src/thread.h
@@ -29,6 +29,7 @@
 */
 #if defined(_WIN32)
 #include <process.h>
+#include <windows.h>
 typedef unsigned(__stdcall *argon2_thread_func_t)(void *);
 typedef uintptr_t argon2_thread_handle_t;
 #else
@@ -36,6 +37,34 @@ typedef uintptr_t argon2_thread_handle_t;
 typedef void *(*argon2_thread_func_t)(void *);
 typedef pthread_t argon2_thread_handle_t;
 #endif
+
+/* Reusable barrier. pthread_barrier_t needs Android API 24, hence the
+   explicit mutex/condvar implementation. */
+typedef struct argon2_barrier_ {
+#if defined(_WIN32)
+    CRITICAL_SECTION mutex;
+    CONDITION_VARIABLE cond;
+#else
+    pthread_mutex_t mutex;
+    pthread_cond_t cond;
+#endif
+    unsigned int threshold;
+    unsigned int waiting;
+    unsigned int generation; /* bumped on each release, guards wakeups */
+    int aborted;
+} argon2_barrier_t;
+
+/* Returns 0 on success. */
+int argon2_barrier_init(argon2_barrier_t *barrier, unsigned int threshold);
+
+/* Returns 0 when released normally, -1 once aborted. */
+int argon2_barrier_wait(argon2_barrier_t *barrier);
+
+/* Releases every current and future waiter with -1, so that workers can be
+   joined instead of waiting for a count that will never be reached. */
+void argon2_barrier_abort(argon2_barrier_t *barrier);
+
+void argon2_barrier_destroy(argon2_barrier_t *barrier);
 
 /* Creates a thread
  * @param handle pointer to a thread handle, which is the output of this


### PR DESCRIPTION
I switched from a Pixel 7 Pro to a 11 Pro and have some performance regressions when opening my Database(s)[^1]. Opening up a database took up to 30sec instead of 3-7sec (for comparison a iPhone 15 Pro Max is done in <1sec)

I am aware that as general rule is that fewer rounds, but higher memory usage is beneficial in terms of security and an a copy with better parameters[^3] didn't regress for me. (˜1-2sec)

After looking into it (while being aware about #933) i found out that i has something to do with my parameters[^2] and scheduling.

It was a bit of a lengthy debugging session but the TL;DR of it is:
* `fill_memory_blocks()` created and joined a thread per lane per slice per pass (_2048 threads for t=128, p=4_)
* The (new? improved? buggy?) Scheduler on this device saw sustained load since every worker just lives for one segment
* When (most of the time) scheduled on the little cores they crunched thru it in the lowest performance (394-533MHz) tier instead of going up to 2460MHz

So i assume the new scheduler is optimized for energy saving instead of handing over performance for such tasks.

But to this MR: My proposal here reuses the workers and keep them for the whole derivation. This is a Solution which works for me, but it won't be golden bullet for the lack of using NEON nor better (=more modern) build tools. 

I've added the test which i pulled my findings from.

The code could be made simpler with API >=24 because, [`pthread_barrier_t` requires it](https://github.com/android/ndk/issues/336). But let's not try to re-target the App.
FWIW: I haven't tested if re-targeting would also lead to not having the regression at all. (iow: different scheduling patterns depending on the API level) 

In the End for Argon2d, the medians of 5 runs for a optimized native build:
* `t=128, m=32 MiB, p=4`:   `24565 ms` -> `3364 ms`
* `t=128, m=32 MiB, p=1`:   `24162 ms` -> `3083 ms`

[^1]: around 700 Entries, <1 MiB file Size
[^2]: `AES256`/`Argon2id`/`r=128`/`m=32mib`/`p=4`
[^3]: `AES256`/`Argon2id`/`r=2`/`m=512mib`/`p=4`