### PR TITLE
fix: enable unlock button if allow no master key

### DIFF
--- a/app/src/main/java/com/kunzisoft/keepass/activities/MainCredentialActivity.kt
+++ b/app/src/main/java/com/kunzisoft/keepass/activities/MainCredentialActivity.kt
@@ -343,6 +343,7 @@ class MainCredentialActivity : DatabaseModeActivity() {
         }
 
         mMainCredentialViewModel.refreshPreferences()
+        mMainCredentialViewModel.onConditionChanged(mainCredentialView.isFill())
 
         // Back to previous keyboard is setting activated
         if (PreferencesUtil.isKeyboardPreviousDatabaseCredentialsEnable(this@MainCredentialActivity)) {


### PR DESCRIPTION
On the credential screen, the unlock button is disabled by default even if the "Allow no master key" option is enabled. The unlock button is only enabled when state changes (e.g., toggling the password on/off option), resulting in poor UX.

This is because `onfirmButtonEnabled` is initialized to `false` and is only updated when state updates. This PR fixes this issue by triggering `onConditionChanged` to set `onfirmButtonEnabled` to a correct value when the activity initializes.