### PR TITLE
Add support for ML-DSA during passkey creation and authendication

### DIFF
--- a/crypto/src/androidTest/java/com/kunzisoft/encrypt/SignatureTest.kt
+++ b/crypto/src/androidTest/java/com/kunzisoft/encrypt/SignatureTest.kt
@@ -1,6 +1,9 @@
 package com.kunzisoft.encrypt
 
+import com.kunzisoft.encrypt.Signature.convertPrivateKeyToPem
 import com.kunzisoft.encrypt.Signature.fingerprintToUrlSafeBase64
+import com.kunzisoft.encrypt.Signature.generateKeyPair
+import com.kunzisoft.encrypt.Signature.sign
 import org.junit.Assert
 import org.junit.Test
 
@@ -117,7 +120,7 @@ class SignatureTest {
         -----END PRIVATE KEY-----
     """.trimIndent()
 
-    private val ed25519PemInLong =  """
+    private val ed25519PemInLong = """
         -----BEGIN PRIVATE KEY-----
         MFECAQEwBQYDK2VwBCIEIESP8edVGbqoR/pKNmy7j7FV8Y68zrIi/5VEuAJ281K6
         gSEAyJU1wQNaJUeyxPcWjN7xZKZUhCRoIFS/MQvbdd4QE7Q=
@@ -162,18 +165,61 @@ class SignatureTest {
     @Test
     fun testSingleSignature() {
         // Generate random input
-        val fingerprint = "A7:5C:63:72:A0:B6:7D:B0:16:86:B4:7D:F6:8C:91:51:6E:E1:62:29:EE:C4:C0:C6:7D:35:5E:32:20:7C:66:17"
+        val fingerprint =
+            "A7:5C:63:72:A0:B6:7D:B0:16:86:B4:7D:F6:8C:91:51:6E:E1:62:29:EE:C4:C0:C6:7D:35:5E:32:20:7C:66:17"
         val expected = "p1xjcqC2fbAWhrR99oyRUW7hYinuxMDGfTVeMiB8Zhc"
 
-        Assert.assertEquals("Check fingerprint app", expected, fingerprintToUrlSafeBase64(fingerprint))
+        Assert.assertEquals(
+            "Check fingerprint app",
+            expected,
+            fingerprintToUrlSafeBase64(fingerprint)
+        )
     }
 
     @Test
     fun testMultipleSignature() {
         // Generate random input
-        val fingerprint = "A7:5C:63:72:A0:B6:7D:B0:16:86:B4:7D:F6:8C:91:51:6E:E1:62:29:EE:C4:C0:C6:7D:35:5E:32:20:7C:66:17##SIG##DB:25:8A:A6:19:08:9B:D1:3D:BA:71:9E:5A:DA:EC:FF:7F:12:C8:8F:67:AD:68:3C:1F:BC:F2:28:B3:88:BD:91"
+        val fingerprint =
+            "A7:5C:63:72:A0:B6:7D:B0:16:86:B4:7D:F6:8C:91:51:6E:E1:62:29:EE:C4:C0:C6:7D:35:5E:32:20:7C:66:17##SIG##DB:25:8A:A6:19:08:9B:D1:3D:BA:71:9E:5A:DA:EC:FF:7F:12:C8:8F:67:AD:68:3C:1F:BC:F2:28:B3:88:BD:91"
         val expected = "p1xjcqC2fbAWhrR99oyRUW7hYinuxMDGfTVeMiB8Zhc"
 
-        Assert.assertEquals("Check fingerprint app", expected, fingerprintToUrlSafeBase64(fingerprint))
+        Assert.assertEquals(
+            "Check fingerprint app",
+            expected,
+            fingerprintToUrlSafeBase64(fingerprint)
+        )
     }
+
+
+    // region ML-DSA
+    @Test
+    fun testMlDsa44() {
+        checkMlDsaGenerateAndSign(-48)
+    }
+
+    @Test
+    fun testMlDsa65() {
+        checkMlDsaGenerateAndSign(-49)
+    }
+
+    @Test
+    fun testMlDsa87() {
+        checkMlDsaGenerateAndSign(-50)
+    }
+
+    fun checkMlDsaGenerateAndSign(id: Long) {
+        val keyPairNullable = generateKeyPair(listOf(id))
+        assert(keyPairNullable != null) { "no keyPair for $id was generated" }
+
+        val keyPair = keyPairNullable!!
+        assert(keyPair.second == id) { "wrong algorithm id" }
+
+        val pem = convertPrivateKeyToPem(keyPair.first.private)
+        assert(pem.size > 1)
+
+        val sig = sign(pem, "the test message".toByteArray())
+        assert(sig.size > 1)
+    }
+
+    // end region
 }

--- a/crypto/src/androidTest/java/com/kunzisoft/encrypt/SignatureTest.kt
+++ b/crypto/src/androidTest/java/com/kunzisoft/encrypt/SignatureTest.kt
@@ -216,6 +216,10 @@ class SignatureTest {
 
         val pem = convertPrivateKeyToPem(keyPair.first.private)
         assert(pem.size > 1)
+        val pemSpilted = String(pem).split("\n")
+
+        // see https://www.rfc-editor.org/rfc/rfc9881.html#name-private-key-format
+        assert(pemSpilted.size == 4)
 
         val sig = sign(pem, "the test message".toByteArray())
         assert(sig.size > 1)

--- a/crypto/src/androidTest/java/com/kunzisoft/encrypt/SignatureTest.kt
+++ b/crypto/src/androidTest/java/com/kunzisoft/encrypt/SignatureTest.kt
@@ -1,6 +1,7 @@
 package com.kunzisoft.encrypt
 
 import com.kunzisoft.encrypt.Signature.convertPrivateKeyToPem
+import com.kunzisoft.encrypt.Signature.createPrivateKey
 import com.kunzisoft.encrypt.Signature.fingerprintToUrlSafeBase64
 import com.kunzisoft.encrypt.Signature.generateKeyPair
 import com.kunzisoft.encrypt.Signature.sign
@@ -192,6 +193,51 @@ class SignatureTest {
 
 
     // region ML-DSA
+
+    @Test
+    fun testSeedOnly() {
+        val privateKey = createPrivateKey(SignatureTestData.mlDsa44SeedOnly.toCharArray())
+        val pem = convertPrivateKeyToPem(privateKey)
+        assert(checkPem(pem))
+    }
+
+    @Test
+    fun testSeedAndPrivateKeyOnly() {
+        val privateKey = createPrivateKey(SignatureTestData.mlDsa44SeedAndPrivateKey.toCharArray())
+        val pem = convertPrivateKeyToPem(privateKey)
+        assert(checkPem(pem))
+    }
+
+    @Test
+    fun testPrivateKeyWithoutSeedIsUnsupported() {
+        val keyAsPem = SignatureTestData.mlDsa44PrivateKeyWithoutSeed.toCharArray()
+        val privateKey = createPrivateKey(keyAsPem)
+        try {
+            convertPrivateKeyToPem(privateKey)
+
+            assert(false) {
+                "the convertPrivateKeyToPem should throw an Exception, " +
+                        "because ML DSA private key without a seed is not supported"
+            }
+        } catch (e: SecurityException) {
+            assert(e.message != null)
+            assert("does not contain the seed" in e.message!!.lowercase())
+            return
+        } catch (otherException: Exception) {
+            assert(false) { "wrong type of Exception: ${otherException.javaClass.name}" }
+        }
+        assert(false)
+    }
+
+    @Test
+    fun testReadMlDsa44Pem() {
+        val privateKey = createPrivateKey(SignatureTestData.mlDsa44SeedOnly.toCharArray())
+        val thePackage = privateKey.javaClass.`package`!!.name.lowercase()
+        val isOpenssl = "openssl" in thePackage
+        assert(isOpenssl.not())
+        assert("bouncycastle" in thePackage)
+    }
+
     @Test
     fun testMlDsa44() {
         checkMlDsaGenerateAndSign(-48)
@@ -215,14 +261,17 @@ class SignatureTest {
         assert(keyPair.second == id) { "wrong algorithm id" }
 
         val pem = convertPrivateKeyToPem(keyPair.first.private)
-        assert(pem.size > 1)
-        val pemSpilted = String(pem).split("\n")
-
-        // see https://www.rfc-editor.org/rfc/rfc9881.html#name-private-key-format
-        assert(pemSpilted.size == 4)
+        assert(checkPem(pem))
 
         val sig = sign(pem, "the test message".toByteArray())
         assert(sig.size > 1)
+    }
+
+    fun checkPem(pem: CharArray): Boolean {
+        val pemSplited = String(pem).split("\n")
+
+        // see https://www.rfc-editor.org/rfc/rfc9881.html#name-private-key-format
+        return pemSplited.size == 4
     }
 
     // end region

--- a/crypto/src/androidTest/java/com/kunzisoft/encrypt/SignatureTestData.kt
+++ b/crypto/src/androidTest/java/com/kunzisoft/encrypt/SignatureTestData.kt
@@ -1,0 +1,145 @@
+package com.kunzisoft.encrypt
+
+/*
+Contains only test data used in `SignatureTest`
+ */
+class SignatureTestData {
+
+    companion object {
+
+        // All private keys are for testing only.
+        // DO NOT USE THEM
+
+        // openssl genpkey -algorithm ML-DSA-44 -provparam ml-dsa.output_formats=seed-only -out mldsa44-seed-only.pem
+        val mlDsa44SeedOnly =
+            """
+                -----BEGIN PRIVATE KEY-----
+                MDQCAQAwCwYJYIZIAWUDBAMRBCKAIFcKtXgQHrAiGiaBG3Y1dUMosQJFhkMHJHZo
+                RXr6/TS0
+                -----END PRIVATE KEY-----
+            """.trimIndent().trim()
+
+        // openssl genpkey -algorithm ML-DSA-44 -provparam ml-dsa.output_formats=seed-priv -out mldsa44-seed-priv.pem
+        val mlDsa44SeedAndPrivateKey =
+            """
+                -----BEGIN PRIVATE KEY-----
+                MIIKPgIBADALBglghkgBZQMEAxEEggoqMIIKJgQgXG1gUVK6J3ZAbZU1r4a/cCxx
+                5cVGx1l1VVNjfcaD2GkEggoARUpWnJTYsYFgySRvvjxrVj42TADCU1m9MJlzM7P4
+                2L7ZWR+Dq1y1VnZLp+OvkA0AdiHQKiAP7ytFDTDXFdZZ9AwTgvFxC2P7O0jU46W3
+                j5JPLTEApYJ16+DARomWfGVGIaa9+9Dtvn4UV1ZwU/Yx7ulJon+LaV4FJ2aAyTco
+                hRgZSIQIEookgyAiSTIMoWRUpkwcJmLZMgggCQXixASigGgIQhHamCQYlElhIkAa
+                B4YAFyaahlAIgY2hwo0hCChJggjgBokCKUqBBGQRsgUQAHJiRApIkCgMuUyjGIDR
+                wAXgBmDBiGULwCQRxW0Yx0wYglAitQSCMAQYRpAkloUTIoEUkg0Up2xAOCKSEBES
+                F27comEYJGYTBFBZgghBIgIclwEMiCmLICiTMAkbAhGYtBHAImhSwE3iMAFYEGBc
+                FiwkIo1ToHBENiqMuCGgMlKRliEbOWAEJyxjBAaUhCxUpEFTqA3SiCVcEigJoChc
+                woibuEgEB2ACEw7SAoBYIJHKkFEaMpIKMGpKFoTMAE4aE1KItGhEImhJtkHcoIWJ
+                pi0ahyjEGISaMAiTKJBcpoRDNExRGIEDSYgjpkkQhQTciCHEwAzbIBELwiRZIhHS
+                OElQNGoLx0ycQJHBACUKk0ELA0bYloxjIGmcmAEQIZBEJDJQQghIyBDQtkwLtmDa
+                JoCAxmykRGFUMmqcJGrYhGwgKSQBIjJEJISDIAYSJ4jbNmTMsoEiMyZcgkTUlAyM
+                RkYJlWgakUWjtkhZICgawiEBRWiaQISJRmjTSIwiklAEEy6JAkkQAUGKJHGEwhEh
+                sgDcEnAZoC1hiGUTRECJMG0hsBGZpmTQtEUTuI0ZkUWixFAYxwAhF2HkllARkU3j
+                sGRkhgjZBEIARnIBMQlgNGQERiHKBkmQFHIYFm4SOQLLppAABkSTRGGYxGABxWAE
+                pmTcJoxUtnFTQpDMInGEwi3hJkIYEk0Asg1CRhHMoI3aREISJUrguEQkSAQAJGLb
+                pIgJtSGRsDGKNkkEASVKRCJJKIkbyJDboiwgkIUiqYyKIFEUORGRKEQcpImMMBIA
+                KCoZNZIbI0QKKCpTOJHchm2DmIAgFAFhGABjRkFKJmwbxlAaNSrYCHDSFmIBJ4YA
+                OZHgMAYiIgETCEAaxSAEM0QYoREaOGXIhHCRtiUUGUjBFFEgCVJcqCljRjHMQGUL
+                yYTP0kva4PJCBkotdgzDtdSToy4CVCDlyKa1Lal/IZqQq0JZ6cbk7XYaaU7aUtqb
+                Twm28kJ9R43YYGOrjti9D3z9x16nEG77cr3TpGvfTpMikwKT82VDf2I6RXFlfS6y
+                U8U6E/bsSIA+Az7CWtE65KvO9N9c5hsonWQXI+tn3DS0kspBapCByO5e2uXvKdSX
+                LVds3E6fzWMFZTyUL1Zvn7qlNnq/6dRZy4PKvJ5Vmx3rVxT32D3nqRPt3jgWAMpc
+                tEzEurg8hX0H6XVzMhh9uAVQ8j4f7er1yGJXxaSPpoy4awYkSHBphcj2pnmZv3uO
+                kRXtgEpDVqy89PlVjB+wdZOb7dMdG/doBuFh+2CpzOYrB7ubSei1NxfePOaIbh44
+                6Xyab8jcyZolbiFdkyWfQeL0bZhGG4iUrQiCvRauSouF72M8kPMoHzvsc5dMz8RN
+                N3wYJ3cRtxoWYZL1p9Lp9Z3CdCFm8gfBcsMe6TC/C5mwsHqwXOVQEB8Ufft6Xdgg
+                zKBrANBLTCRYK81cxTaoPotPMTneTsIQ3VHbXiQMgetlwokXlSwuEFoIlFwSY1Cc
+                h0nncWson9RoYkIA11oY2jD5ow8yYrImT1bimOPh/Y7mBmQsDEkJMemOV2JuJgfu
+                ebtAkb/ReHGUK0QiLKZgacIYjE1RwQscBWQc+XxurCa/6OSbwgX+XIvYMFU55Ahj
+                UoKNqoizkMPpUis1+WcW+34O4GrOnJ0ML0ahFMEdy7xYVjzDArG/O1DZmiO0wmv6
+                YTZI/jJHfJ/fN0He0tNkEUpEUEG+wPbTFpm5DUSv6bwZEhsSquPdWW+FDvzAdZmM
+                njVRhgNukSE7OGMjCR+b91xVhC4uqSVbjnWCgtB2voXj75g5Ql/rxJSAfgoYP0Za
+                eNTHtif5NYvudWyTlnNQy+BfRi8cKvnKugCJKC5TkX45xK+pgmzOyyaBXBVpKwi8
+                7Vh4nu0wKWF1toSq4o+rqsYPm3QVxlXfmTZbP+E3NbMtTyJ33Snz0wZHvJjWpkEG
+                KW+eUZIR2pxiPZ7f7rmPE0OB8EiCd1SFX7XGPxiqTBsgpKP3kU7hHm0bv0To9EdV
+                Y3W9DNoDRORxk2A4ZlVE11q/0rFleCQKsmM6ZQsngDjOY5oJ8YTFi9SuTAxAveuk
+                iaVJE5IttGn2e5iKvrRZK/zA6Gu+UYhIiTLr7mnPtFQb4A/y4K66V89Ei3Dd5S5+
+                UuzRKJtlfeThPr80QcjhykzJpGuVtNm4SDg4SZc61qaoSn46BDXVAqUXM/X7eM7L
+                bZgHfm5XUizIgjXs9Dx921NG9C2NDTPurc2B2SMznmC/A10I6xpLky5O7apd6Q9a
+                DXlq+g72emaUfYYbITHrrClMgJWVQTqVDTiwYsAED0b0zeAcJQP0xJ01nxpstF4g
+                cVlLxh/2OMsoI6xb89RvdmP2n0oQFh4+Z5X7h04obbzm8zuC0a2wsEmRT/uOrX0b
+                9ZFbcV49+5McRds/YJISe8ut3BvOuv43M8STBj10PEGa/Op65BpMS+QCDreIsSuD
+                Vy/x0Ed4RfWVj0lKx+bEDICY/X0TsWJxEJilMK5GOEubmk7maEazOdP6pcApBAty
+                9mIRSZesXX7INBT7kLyfGnrYREnjiFMX4gudGot9BtCtNUXWsOYlO7fjMAn+yA3Q
+                84aM2vZE7PaetEVdNDSV1L5ltYWO1/0KyBd5+uo8wTzAkdt+UggdLwvsCRcwk7xL
+                uIwS7XQ1CEitefo8NDpFbbcQ8WvHORerkmG4ZRuqGz1nYVToi8AkCPWCh8TWYw+9
+                bPWHxDi0fsO68JBFTmIH++zmoLIZFpY/mtoChMcFHH4QgPl/4iYHi1gwP1lZlEAl
+                IXVXH7uuJuPV01/en9gsYBRgijfrc40qC5i54Z2y3B9hAGm67x5QKx1Wnf2GsHbQ
+                dIHGDxFZ0gJ/GEKf8AR4c8uP9wGp9r9yKWxjAbg8YZKb/acG2kdQZhfsjY0/Dchk
+                ATeg2vjyIQZ6F6TwXV6iiW6R6h+QNWuqZgmZkITIX8Pqlnm3e7lBdwkv+OBZHiIt
+                7NrApcrI2gC0+U9YyChl8W0OTVnNb8RVSiOn9tC2n96+oHWs0ikLJJV0cQN/ROFf
+                1c5zp8UKnTiTY7omsYmlq+HzPPP+ShZ6M2uyyUr0JKwkM5M9ybztJZXaY7CmsaR+
+                0QkLzrj5K1PmgY8Uk3cQRXmauw6ThL9jcqx+Fy8G5QOuqA==
+                -----END PRIVATE KEY-----
+            """.trimIndent().trim()
+
+        // openssl genpkey -algorithm ML-DSA-44 -provparam ml-dsa.output_formats=priv-only -out mldsa44-priv-only.pem
+        val mlDsa44PrivateKeyWithoutSeed =
+            """
+            -----BEGIN PRIVATE KEY-----
+            MIIKGAIBADALBglghkgBZQMEAxEEggoEBIIKAHJPbF6N+RXQC/ptRU0r+VhTAk4q
+            ux3E++UCroYbT45rTHPy7QZEvdvmDbfahfL7AUYmc1RLjMeLtRBv9EhAcWSeesjt
+            27VQ9J3UvCbkOAHFJZC6CAlnqRmOGOPlAkRUsxjmnbhu7fhCHdluziwCIvQfWmdc
+            eud6dcn4xccsh9+1gKAQXKaRCxlwEKKEAyNF3BZqXCgMIMBJIKNEIDUiGAMSG8GJ
+            QsANUygCYEaFCBkqIUgpWDBm08BA4rYwGbBJADRx08ANUEhqEgNFi8AQFAGQCwFp
+            TJQoCQJoAimODBlwBMRhAIWICIcgWDRCUKAgUEgtlIhJGjRtEzkCkCBCwJiBiBAF
+            SkQOExMwQyZmmcAwADEJwZIoSZQp2hCCIogogSBwCkWEzIQFGzgIWAINUUIBoYYt
+            ykZsDBdIohhAkgYMIRNhALNw0EJsABcFjKZAA0NOi0AGmcBlCIhpkkBpBCVywoKM
+            WRhOQUgmTJAAEUeAgTaCBKlQgbRsmbiNSZQJIrhtIUBFHIZogoRpABBhUBIgEQGN
+            pCCKCgQFixJQkLYNQRBBJDJJWKiRzERI2sQw4kARgRYq4TKKoRIJWsgBSERGkDBS
+            EwGNGQllychFJCgQFEUI0SSRkxZqQSiQYwIg0qBlUgCN2hQigsZhUiCQU8RlS8AN
+            oxaO2AaSkZCMAiIM4USC4wIwkQhhEweNCzVFyCZogDglJAFkIoiQS0hqQsiN4BQR
+            28JQGjeNEZFwSCCKhCRFVLKQIiWFgcRN4ZgRohAEEcAlHCRBlBIMoTAulDIRk6QM
+            oQBhjBKOiLQQSpQsEwgBHEBt3DYqjESMACNQE0REo6iEIqJRAidoXBQNUshMW6ZJ
+            SaiFBMOR2yYQCsgEiEJFCRQOE0eG2RSBmEQtkoJFFLgAGqNMILGAYxKAmDZsmxBg
+            WAhGWTKRUYSMCBIqUQZCUJCJAKgNyJggWERs4kBioEZuY8YBwMYJyzRiEzhyyJCJ
+            ohARGRaNASVyI8NJTIANWgYEYkQg4TgQA6CI2jQQwCZBJEhwCcEMoJIgQCaOCzBR
+            mwgMWUZpJLdBI7lg0BBIIBVgRJZxUCIK4rIQQcJNIwUqWEJJpJRIwLaIQRIoBBUK
+            SiiAIcMwxIJBUKAJYyAQXDYNyTAtDMgk4YYpCqlFWSIi2khRG7AxGqaFohRSIEOO
+            FIAo2ghC0wgJzEZioKC8NkjSXWj+A9j+ozEzeUUCh8Vol8xekAOK6//sUUkr4739
+            zGRj5y3SG/7T5wHUTI/qj3pvStOMc62Xca/+qjqpEhekmvBsVpWMZwwKoLEfLoFN
+            be4EFCZjvSNtrZ51Sfxc/DAk865YXo7e1ExEhlkhHD8EusIRD+YUIxvK69j4Bqcs
+            4smJnGOnrTdnxScu+MwWkA+H8JkTfLwHKfcQz19S1YBV3n4n134E+phRJ3MQq2dw
+            p0DYrjwBo4aPgJyoP3TE7qMUlUDO28HCOgX2Yg7PQu0TaN9G2/oAnRktnodDzyq1
+            Lp89gDbS9O9CKo5zObyhOqwyaCbkTulFBjgnEloksrwIoNN2M3+svm5FAsw0ZeK7
+            XbXf0iqQGibihVtbKzqH+ydeG6tU0cx4tj2gW9WNYdhr5jti4XJ5ivXnCsvxw2uU
+            bwll6cJ5rNvNsVFc2wOuQkxKaVQYk4REvJ4jR7yV0DT8Ss/C7TZGqdkdH3ZbuB/z
+            V9JqlMGt09DGpgWwARzSc5ybxakxSra4AeiwZl1hDzt5NOX41i08ry8ClNgva4S/
+            OQYDeuSnSkH/iKyGq8nJUe4xCQxOhkuTDoFvguQLCpilF+WFjbpgxK9SJ1USwqog
+            QEtrUMoHtVA5u2ktrwriUkOARbr13gd/6MD6eKV3e+JjNf5VmNkQMdHCuN329USY
+            0icXIoPhiM2jbpS81vNo7Ca7fKsn4rrrxMkgDyZ+8EtUnHcVHCfWsNnpvW4HAxOi
+            XWUBwog0qWp+xIsaVI5jbbxHmKvEYYKkpAzGXEDUuhYM9TsNFHEooSz94C9PYaBO
+            4LESW2qujJ+848lOnxSuMl7A8xWYVSXsoQefKvrMLyT6XM8Pe5ixFCXDLNL2CiR3
+            6rdBMISZzmMqtsURYvzQQIxTCiekoZgnTVr5Txwqlv26eH5+jwDz0d8cbgDddAok
+            ny+VaJjxKD/rZMxkIYgolRVNsY45M4tIawu0Ud2EhuwJ2t5jV8ALJvsBcSS2MPY8
+            gSPYbd6N0B0fOzzMpMQc/yxoHYe45LCR125vrIOKiI+D2DGdRelRRIA5rcapm6kO
+            1LaVxOxw89yF6A4OpsEotpETsuNk1NJMAJtnWWoGyGvVnTgWq7Vk2rCwRAyfpdqe
+            Cs/QUvtmceH5a4mHf1Izi3Q2RDZUxVp4Yd1Hpx+hGiVrozSBj1vNtXilYnuo5A/l
+            Ecu68x5YzDUUsP8W3vsT5XVkrX/Dpji36w3wowPWK6x87zWlPqgGUjui78x8WbKM
+            uDw2g79TxFIIzmPyVOt3sDOIW0WdmlS8eAW1hAcEDtDAUsIcd6h1CbbYcGvibjQf
+            ac99KrD3apuVbQ/n7k9IjJy2n9xcVT9lLuk93U9j7Hy3ysR3e3NolJHCDGn7oErI
+            5TaA9d5ua0OAsX5cp0IqUV2QBrz60NaenLLyRwjfCgi208D8ABX/cf4AfPfJujrY
+            UHFoeU+cWmd2K7PoDRJ3IOBikYoAW/BfUe/3bsrwVouD60JBe3/0Azgqacv8y2kH
+            6KvDYg9sanEJ4e9cAjNiYxeuwmbRiNDnP+D6pV70JNHGKhGP/knjW8OuMaBrT0Ru
+            q6OvZ3CNQu+fsDp+5fMyEo/16UJLuUYnqRA2mDny/w7+e6/3DRgJqw2av4+k/lhD
+            vvdcbhdVG2mzE162/VFpjPFBB05J0p8QQI1TIxfNAL2AfPv8bgsued2NvXf/gX4U
+            ei71c0SgOMtH+Z97HP6CsKBjSegTYGg3fk33Xqvp/Gbb25vfit2Q71+2NMxUBGFM
+            2WofPQKo32duhDFse+4tlyv6Acd1s6R+95vz0SXUPaF6c0vt80U4mdYMaApdJmN8
+            eEubyi+5yvpXYxw2YFS0zhRaQUbqUYyAG/vgik4fherqM4v8awVzKWhjiQofMfOl
+            3IqlXdYTvFdgNyJLGGZixdh55XzpDXopAyH72LAI97hR6TP4odr1kzOZnLf1A+vx
+            T1OZp7UpNkw1BNfAKIpaL0X6bd7tORdX6zLULbf6Mq8cK3LVHDR9tpk8bGVGbOv3
+            jPnCyus+yZoOMmqmiM3HYbX7N50LXcfcdMAKK0/q8t9ePT2dpJCJa5JolBHJh2uz
+            UzigZUSmTA6IJ7lKHwhwo1EwBTrJcTfdPdcXdsNX6wO/DvPJkg3jEqZishDxnMxm
+            c0EuHlmBC0PqDn2ken/RpFW6vPAo1gU5+eyUhfKht4MckQGdjzPFtSHdEl4=
+            -----END PRIVATE KEY-----
+        """.trimIndent().trim()
+    }
+}

--- a/crypto/src/main/java/com/kunzisoft/encrypt/Signature.kt
+++ b/crypto/src/main/java/com/kunzisoft/encrypt/Signature.kt
@@ -25,6 +25,8 @@ import android.util.AndroidException
 import android.util.Log
 import org.bouncycastle.asn1.pkcs.PrivateKeyInfo
 import org.bouncycastle.crypto.params.Ed25519PublicKeyParameters
+import org.bouncycastle.jcajce.interfaces.MLDSAPrivateKey
+import org.bouncycastle.jcajce.interfaces.MLDSAPublicKey
 import org.bouncycastle.jcajce.provider.asymmetric.ec.BCECPublicKey
 import org.bouncycastle.jcajce.provider.asymmetric.edec.BCEdDSAPrivateKey
 import org.bouncycastle.jcajce.provider.asymmetric.edec.BCEdDSAPublicKey
@@ -35,6 +37,7 @@ import org.bouncycastle.jce.provider.BouncyCastleProvider
 import org.bouncycastle.openssl.PEMParser
 import org.bouncycastle.openssl.jcajce.JcaPEMKeyConverter
 import org.bouncycastle.openssl.jcajce.JcaPKCS8Generator
+import org.bouncycastle.operator.DefaultSignatureAlgorithmIdentifierFinder
 import org.bouncycastle.util.BigIntegers
 import org.bouncycastle.util.io.pem.PemWriter
 import java.io.CharArrayReader
@@ -60,12 +63,17 @@ object Signature {
 
     const val ED_DSA_ALGORITHM: Long = -8
 
-    const val ML_DSA_44_ALGORITHM: Long = -48
-    const val ML_DSA_65_ALGORITHM: Long = -49
-    const val ML_DSA_87_ALGORITHM: Long = -50
+    private const val ML_DSA_44_ALGORITHM: Long = -48
+    private const val ML_DSA_65_ALGORITHM: Long = -49
+    private const val ML_DSA_87_ALGORITHM: Long = -50
 
-    val ML_DSA_ALGORITHM_LIST = listOf(ML_DSA_44_ALGORITHM, ML_DSA_65_ALGORITHM, ML_DSA_87_ALGORITHM)
+    private val ML_DSA_ALGORITHM_LIST =
+        listOf(ML_DSA_44_ALGORITHM, ML_DSA_65_ALGORITHM, ML_DSA_87_ALGORITHM)
 
+
+    // https://www.iana.org/assignments/cose/cose.xhtml#key-common-parameters
+    private const val COSE_KEY_TYPE_LABEL = 1
+    private const val COSE_ALGORITHM_LABEL = 3
 
     private const val BEGIN_PRIVATE_KEY = "-----BEGIN PRIVATE KEY-----"
     private const val BEGIN_PRIVATE_KEY_LINE_BREAK = "$BEGIN_PRIVATE_KEY\n"
@@ -77,12 +85,17 @@ object Signature {
     private const val OID_EC = "1.2.840.10045.2.1"
     private const val OID_ED25519 = "1.3.101.112"
 
+    private val OID_ML_DSA_44 = findOID("ML-DSA-44")
+    private val OID_ML_DSA_65 = findOID("ML-DSA-65")
+    private val OID_ML_DSA_87 = findOID("ML-DSA-87")
+
+    private val OID_ML_DSA_LIST = listOf(OID_ML_DSA_44, OID_ML_DSA_65, OID_ML_DSA_87)
+
     private const val BOUNCY_CASTLE_PROVIDER_NAME = BouncyCastleProvider.PROVIDER_NAME
 
     init {
         Security.removeProvider(BOUNCY_CASTLE_PROVIDER_NAME)
-        val mostPreferredPosition = 1 // not 0 based
-        Security.insertProviderAt(BouncyCastleProvider(), mostPreferredPosition)
+        Security.addProvider(BouncyCastleProvider())
     }
 
     fun sign(privateKeyPem: CharArray, message: ByteArray): ByteArray {
@@ -92,7 +105,7 @@ object Signature {
             "EC", "ECDSA", OID_EC -> "SHA256withECDSA"
             "RSA", OID_RSA -> "SHA256withRSA"
             "Ed25519", OID_ED25519 -> "Ed25519"
-            "ML-DSA-44", "ML-DSA-65", "ML-DSA-87" -> "MLDSA"
+            "ML-DSA-44", "ML-DSA-65", "ML-DSA-87", "ML-DSA" -> "MLDSA"
             else -> throw SecurityException("$algorithmKey algorithm is unknown")
         }
         val sig = Signature.getInstance(
@@ -133,12 +146,10 @@ object Signature {
                 workingBuffer = tempBuffer
             }
 
-            return PEMParser(CharArrayReader(workingBuffer)).use { pemParser ->
-                val obj = pemParser.readObject()
-                val privateKeyInfo = obj as? PrivateKeyInfo
-                    ?: throw SecurityException("Invalid private key format or encrypted key not supported (type: ${obj?.javaClass?.name})")
-                JcaPEMKeyConverter().getPrivateKey(privateKeyInfo)
-            }
+            return PEMParser(CharArrayReader(workingBuffer))
+                .use { pemParser ->
+                    readWithPemParser(pemParser)
+                }
         } finally {
             // Securely wipe the input and any temporary buffers from memory
             privateKeyPem.fill('0')
@@ -146,11 +157,24 @@ object Signature {
         }
     }
 
+    private fun readWithPemParser(pemParser: PEMParser): PrivateKey {
+        val obj = pemParser.readObject()
+        val privateKeyInfo = obj as? PrivateKeyInfo
+            ?: throw SecurityException("Invalid private key format or encrypted key not supported (type: ${obj?.javaClass?.name})")
+
+        // necessary to enforce the use of the Bouncy Castle class
+        if (privateKeyInfo.privateKeyAlgorithm.algorithm.id in OID_ML_DSA_LIST) {
+            return BCMLDSAPrivateKey(privateKeyInfo)
+        }
+
+        return JcaPEMKeyConverter().getPrivateKey(privateKeyInfo)
+    }
+
     fun convertPrivateKeyToPem(privateKeyIn: PrivateKey): CharArray {
         var privateKey = privateKeyIn
 
         // for ML-DSA
-        if (privateKey is BCMLDSAPrivateKey) {
+        if (privateKey is MLDSAPrivateKey) {
             privateKey.seed ?: throw SecurityException("private ML-DSA does not contain the seed")
 
             // the pem is only 4 lines long, instead of 56, 87 or 105 lines respectively
@@ -284,17 +308,13 @@ object Signature {
         } else if (keyTypeId == ED_DSA_ALGORITHM) {
             return publicKeyIn.encoded
         } else if (keyTypeId in ML_DSA_ALGORITHM_LIST) {
-            return  publicKeyIn.encoded
+            return publicKeyIn.encoded
         }
         Log.e(this::class.java.simpleName, "convertPublicKey: unknown key type id found")
         return null
     }
 
     fun convertPublicKeyToMap(publicKeyIn: PublicKey, keyTypeId: Long): Map<Int, Any>? {
-
-        // https://www.iana.org/assignments/cose/cose.xhtml#key-common-parameters
-        val keyTypeLabel = 1
-        val algorithmLabel = 3
 
         if (keyTypeId == ES256_ALGORITHM) {
             if (publicKeyIn !is BCECPublicKey) {
@@ -310,8 +330,8 @@ object Signature {
             val es256KeyTypeId = 2
             val es256EllipticCurveP256Id = 1
 
-            publicKeyMap[keyTypeLabel] = es256KeyTypeId
-            publicKeyMap[algorithmLabel] = ES256_ALGORITHM
+            publicKeyMap[COSE_KEY_TYPE_LABEL] = es256KeyTypeId
+            publicKeyMap[COSE_ALGORITHM_LABEL] = ES256_ALGORITHM
 
             publicKeyMap[-1] = es256EllipticCurveP256Id
 
@@ -337,8 +357,8 @@ object Signature {
             val rs256ExponentSizeInBytes = 3
 
             val publicKeyMap = mutableMapOf<Int, Any>()
-            publicKeyMap[keyTypeLabel] = rs256KeyTypeId
-            publicKeyMap[algorithmLabel] = RS256_ALGORITHM
+            publicKeyMap[COSE_KEY_TYPE_LABEL] = rs256KeyTypeId
+            publicKeyMap[COSE_ALGORITHM_LABEL] = RS256_ALGORITHM
             publicKeyMap[-1] =
                 BigIntegers.asUnsignedByteArray(rs256KeySizeInBytes, publicKeyIn.modulus)
             publicKeyMap[-2] =
@@ -366,8 +386,8 @@ object Signature {
 
             val publicKeyLabel = -2
 
-            publicKeyMap[keyTypeLabel] = octetKeyPairId
-            publicKeyMap[algorithmLabel] = ED_DSA_ALGORITHM
+            publicKeyMap[COSE_KEY_TYPE_LABEL] = octetKeyPairId
+            publicKeyMap[COSE_ALGORITHM_LABEL] = ED_DSA_ALGORITHM
 
             publicKeyMap[curveLabel] = ed25519CurveId
 
@@ -379,10 +399,42 @@ object Signature {
             )
 
             return publicKeyMap
+        } else if (keyTypeId in ML_DSA_ALGORITHM_LIST) {
+            return convertPublicKeyToMapMlDsa(publicKeyIn, keyTypeId)
         }
 
         Log.e(this::class.java.simpleName, "convertPublicKeyToMap: no known key type id found")
         return null
+    }
+
+    private fun convertPublicKeyToMapMlDsa(
+        publicKeyIn: PublicKey,
+        keyTypeId: Long
+    ): Map<Int, Any>? {
+        if (publicKeyIn !is MLDSAPublicKey) {
+            val msg =
+                "publicKey object has wrong type for keyTypeId $keyTypeId: ${publicKeyIn.javaClass.canonicalName}"
+            Log.e(this::class.java.simpleName, msg)
+            return null
+        }
+
+        val publicKeyMap = mutableMapOf<Int, Any>()
+
+        // https://datatracker.ietf.org/doc/html/rfc9964
+        val algorithmKeyPairId = 7 // AKP for short
+        publicKeyMap[COSE_KEY_TYPE_LABEL] = algorithmKeyPairId
+        publicKeyMap[COSE_ALGORITHM_LABEL] = keyTypeId
+
+        val encodedPublicKey = convertPublicKey(publicKeyIn, keyTypeId)
+        if (encodedPublicKey == null) {
+            val msg = "the encoded ML-DSA public key for COSE is null"
+            Log.e(this::class.java.simpleName, msg)
+            return null
+        }
+
+        val akpPublicKeyId = -1
+        publicKeyMap[akpPublicKeyId] = publicKeyIn.publicData
+        return publicKeyMap
     }
 
 
@@ -502,5 +554,9 @@ object Signature {
             }
         }
         return Base64Helper.b64Encode(hashBytes)
+    }
+
+    fun findOID(signatureAlgorithm: String): String {
+        return DefaultSignatureAlgorithmIdentifierFinder().find(signatureAlgorithm).algorithm.id
     }
 }

--- a/crypto/src/main/java/com/kunzisoft/encrypt/Signature.kt
+++ b/crypto/src/main/java/com/kunzisoft/encrypt/Signature.kt
@@ -28,7 +28,9 @@ import org.bouncycastle.crypto.params.Ed25519PublicKeyParameters
 import org.bouncycastle.jcajce.provider.asymmetric.ec.BCECPublicKey
 import org.bouncycastle.jcajce.provider.asymmetric.edec.BCEdDSAPrivateKey
 import org.bouncycastle.jcajce.provider.asymmetric.edec.BCEdDSAPublicKey
+import org.bouncycastle.jcajce.provider.asymmetric.mldsa.BCMLDSAPrivateKey
 import org.bouncycastle.jcajce.provider.asymmetric.rsa.BCRSAPublicKey
+import org.bouncycastle.jcajce.spec.MLDSAParameterSpec
 import org.bouncycastle.jce.provider.BouncyCastleProvider
 import org.bouncycastle.openssl.PEMParser
 import org.bouncycastle.openssl.jcajce.JcaPEMKeyConverter
@@ -58,32 +60,42 @@ object Signature {
 
     const val ED_DSA_ALGORITHM: Long = -8
 
+    const val ML_DSA_44_ALGORITHM: Long = -48
+    const val ML_DSA_65_ALGORITHM: Long = -49
+    const val ML_DSA_87_ALGORITHM: Long = -50
+
+
     private const val BEGIN_PRIVATE_KEY = "-----BEGIN PRIVATE KEY-----"
     private const val BEGIN_PRIVATE_KEY_LINE_BREAK = "$BEGIN_PRIVATE_KEY\n"
     private const val END_PRIVATE_KEY = "-----END PRIVATE KEY-----"
-    private const val  END_PRIVATE_KEY_LINE_BREAK = "\n$END_PRIVATE_KEY"
+    private const val END_PRIVATE_KEY_LINE_BREAK = "\n$END_PRIVATE_KEY"
 
     // OIDs for algorithms
     private const val OID_RSA = "1.2.840.113549.1.1.1"
     private const val OID_EC = "1.2.840.10045.2.1"
     private const val OID_ED25519 = "1.3.101.112"
 
+    private const val BOUNCY_CASTLE_PROVIDER_NAME = BouncyCastleProvider.PROVIDER_NAME
+
     init {
-        Security.removeProvider(BouncyCastleProvider.PROVIDER_NAME)
-        Security.addProvider(BouncyCastleProvider())
+        Security.removeProvider(BOUNCY_CASTLE_PROVIDER_NAME)
+        val mostPreferredPosition = 1 // not 0 based
+        Security.insertProviderAt(BouncyCastleProvider(), mostPreferredPosition)
     }
 
     fun sign(privateKeyPem: CharArray, message: ByteArray): ByteArray {
         val privateKey = createPrivateKey(privateKeyPem)
+
         val algorithmSignature = when (val algorithmKey = privateKey.algorithm) {
             "EC", "ECDSA", OID_EC -> "SHA256withECDSA"
             "RSA", OID_RSA -> "SHA256withRSA"
             "Ed25519", OID_ED25519 -> "Ed25519"
+            "ML-DSA-44", "ML-DSA-65", "ML-DSA-87" -> "MLDSA"
             else -> throw SecurityException("$algorithmKey algorithm is unknown")
         }
         val sig = Signature.getInstance(
             algorithmSignature,
-            BouncyCastleProvider.PROVIDER_NAME
+            BOUNCY_CASTLE_PROVIDER_NAME
         )
         sig.initSign(privateKey)
         sig.update(message)
@@ -108,10 +120,12 @@ object Signature {
                 val pemString = String(workingBuffer)
                 var normalized = pemString
                 if (needsPrefixFix) {
-                    normalized = BEGIN_PRIVATE_KEY_LINE_BREAK + normalized.removePrefix(BEGIN_PRIVATE_KEY)
+                    normalized =
+                        BEGIN_PRIVATE_KEY_LINE_BREAK + normalized.removePrefix(BEGIN_PRIVATE_KEY)
                 }
                 if (needsSuffixFix) {
-                    normalized = normalized.removeSuffix(END_PRIVATE_KEY) + END_PRIVATE_KEY_LINE_BREAK
+                    normalized =
+                        normalized.removeSuffix(END_PRIVATE_KEY) + END_PRIVATE_KEY_LINE_BREAK
                 }
                 tempBuffer = normalized.toCharArray()
                 workingBuffer = tempBuffer
@@ -130,7 +144,19 @@ object Signature {
         }
     }
 
-    fun convertPrivateKeyToPem(privateKey: PrivateKey): CharArray {
+    fun convertPrivateKeyToPem(privateKeyIn: PrivateKey): CharArray {
+        var privateKey = privateKeyIn
+
+        // for ML-DSA
+        if (privateKey is BCMLDSAPrivateKey) {
+            privateKey.seed ?: throw SecurityException("private ML-DSA does not contain the seed")
+
+            // the pem is only 4 lines long, instead of 56, 87 or 105 lines respectively
+            val preferSeedOnlyEnabled = true
+            privateKey = privateKey.getPrivateKey(preferSeedOnlyEnabled)
+        }
+
+        // for ED25519
         var useV1Info = false
         if (privateKey is BCEdDSAPrivateKey) {
             // to generate PEM, which are compatible to KeepassXC
@@ -194,31 +220,55 @@ object Signature {
                     val es256CurveNameBC = "secp256r1"
                     val spec = ECGenParameterSpec(es256CurveNameBC)
                     val keyPairGen =
-                        KeyPairGenerator.getInstance("EC", BouncyCastleProvider.PROVIDER_NAME)
+                        KeyPairGenerator.getInstance("EC", BOUNCY_CASTLE_PROVIDER_NAME)
                     keyPairGen.initialize(spec)
                     val keyPair = keyPairGen.genKeyPair()
                     return Pair(keyPair, ES256_ALGORITHM)
 
                 }
+
                 RS256_ALGORITHM -> {
                     val keyPairGen =
-                        KeyPairGenerator.getInstance("RSA", BouncyCastleProvider.PROVIDER_NAME)
+                        KeyPairGenerator.getInstance("RSA", BOUNCY_CASTLE_PROVIDER_NAME)
                     keyPairGen.initialize(RS256_KEY_SIZE_IN_BITS)
                     val keyPair = keyPairGen.genKeyPair()
                     return Pair(keyPair, RS256_ALGORITHM)
 
                 }
+
                 ED_DSA_ALGORITHM -> {
                     val keyPairGen =
-                        KeyPairGenerator.getInstance("Ed25519", BouncyCastleProvider.PROVIDER_NAME)
+                        KeyPairGenerator.getInstance("Ed25519", BOUNCY_CASTLE_PROVIDER_NAME)
                     val keyPair = keyPairGen.genKeyPair()
                     return Pair(keyPair, ED_DSA_ALGORITHM)
+                }
+
+                ML_DSA_44_ALGORITHM -> {
+                    return generateKeyPairMlDsa(typeId, MLDSAParameterSpec.ml_dsa_44)
+                }
+
+                ML_DSA_65_ALGORITHM -> {
+                    return generateKeyPairMlDsa(typeId, MLDSAParameterSpec.ml_dsa_65)
+                }
+
+                ML_DSA_87_ALGORITHM -> {
+                    return generateKeyPairMlDsa(typeId, MLDSAParameterSpec.ml_dsa_87)
                 }
             }
         }
 
         Log.e(this::class.java.simpleName, "generateKeyPair: no known key type id found")
         return null
+    }
+
+    private fun generateKeyPairMlDsa(
+        mlDsaAlgorithmTypeId: Long,
+        mlDsaParameterSpec: MLDSAParameterSpec
+    ): Pair<KeyPair, Long> {
+        val keyPairGen = KeyPairGenerator.getInstance("MLDSA", BOUNCY_CASTLE_PROVIDER_NAME);
+        keyPairGen.initialize(mlDsaParameterSpec);
+        val keyPair = keyPairGen.genKeyPair();
+        return Pair(keyPair, mlDsaAlgorithmTypeId)
     }
 
     fun convertPublicKey(publicKeyIn: PublicKey, keyTypeId: Long): ByteArray? {
@@ -441,7 +491,10 @@ object Signature {
                 val byteValue = hexStringNoColons.substring(index, index + 2).toInt(16)
                 hashBytes[i] = byteValue.toByte()
             } catch (e: NumberFormatException) {
-                throw IllegalArgumentException("Invalid hex character in fingerprint: $hexStringNoColons", e)
+                throw IllegalArgumentException(
+                    "Invalid hex character in fingerprint: $hexStringNoColons",
+                    e
+                )
             }
         }
         return Base64Helper.b64Encode(hashBytes)

--- a/crypto/src/main/java/com/kunzisoft/encrypt/Signature.kt
+++ b/crypto/src/main/java/com/kunzisoft/encrypt/Signature.kt
@@ -64,6 +64,8 @@ object Signature {
     const val ML_DSA_65_ALGORITHM: Long = -49
     const val ML_DSA_87_ALGORITHM: Long = -50
 
+    val ML_DSA_ALGORITHM_LIST = listOf(ML_DSA_44_ALGORITHM, ML_DSA_65_ALGORITHM, ML_DSA_87_ALGORITHM)
+
 
     private const val BEGIN_PRIVATE_KEY = "-----BEGIN PRIVATE KEY-----"
     private const val BEGIN_PRIVATE_KEY_LINE_BREAK = "$BEGIN_PRIVATE_KEY\n"
@@ -281,6 +283,8 @@ object Signature {
             return publicKeyIn.encoded
         } else if (keyTypeId == ED_DSA_ALGORITHM) {
             return publicKeyIn.encoded
+        } else if (keyTypeId in ML_DSA_ALGORITHM_LIST) {
+            return  publicKeyIn.encoded
         }
         Log.e(this::class.java.simpleName, "convertPublicKey: unknown key type id found")
         return null


### PR DESCRIPTION
Details are described in [issue 2695](https://github.com/Kunzisoft/KeePassDX/issues/2695). The implementation was tested with https://webauthn.io for "ML-DSA 44", "ML-DSA 65" and "ML-DSA 87". 